### PR TITLE
ImPlot v1.0 and pybind11 v3.0.4

### DIFF
--- a/examples/images.py
+++ b/examples/images.py
@@ -3,9 +3,7 @@ Example of how to load and use images and textures
 in a couple different methods
 """
 
-import sys
 import os
-import numpy as np
 
 # Import a basic main loop for a simple UI
 # This is included with the library for you to use as well
@@ -33,6 +31,8 @@ SIZE = 255
 # Load via OpenCV
 def loadOpenCV(filename: str) -> im.Texture:
     image = cv2.imread(filename, cv2.IMREAD_UNCHANGED)
+    if image is None:
+        raise RuntimeError()
     # Might need to convert the colors here
     image = cv2.cvtColor(image, cv2.COLOR_BGRA2RGBA)
     # Pass the data to imgui

--- a/examples/implot_example.py
+++ b/examples/implot_example.py
@@ -40,6 +40,13 @@ class State:
         self.plotY = np.array(
             np.random.rand(self.plotSize) * self.plotMax, dtype=np.float64
         )
+        self.colors = imgui.ImU32List()
+        for _ in range(self.plotSize):
+            self.colors.append(
+                imgui.Vec4(
+                    random.random(), random.random(), random.random(), 1.0
+                ).toColorU32()
+            )
         self.plotIdx = 0
 
         self.lastUpate = 0
@@ -57,15 +64,16 @@ class State:
                 implot.SetNextAxesToFit()
             if imgui.RadioButton("Custom Getter", self.plotMode == 2):
                 self.plotMode = 2
-                implot.SetNextAxesToFit()
+                implot.SetNextAxesLimits(
+                    -0.1, 200, -1.1, 1.1, cond=implot.Cond.Always
+                )
 
             if implot.BeginPlot("data", imgui.Vec2(500, 500)):
                 if self.plotMode == 0:
-                    # The return value from this has to exist until the PlotXXX function
-                    # is called
-                    formatterData = implot.SetupAxisFormat(
-                        implot.Axis.X1, formatterCallback, "data"
-                    )
+                    # The return value from this has to exist until the plot is ended
+                    # implot.SetupAxisFormat(
+                    #     implot.Axis.X1, formatterCallback, "data"
+                    # )
                     if self.lastUpate > self.updatePeriod:
                         self.plotY[
                             self.plotIdx
@@ -73,7 +81,19 @@ class State:
                         self.plotIdx = (self.plotIdx + 1) % self.plotSize
                         self.lastUpate = 0
 
-                    implot.PlotScatter("DATA", self.plotX, self.plotY)
+                    implot.PlotScatter(
+                        "Scatter",
+                        self.plotX,
+                        self.plotY,
+                        (
+                            implot.PlotProp.LineColor,
+                            imgui.Vec4(0.2, 1.0, 1.0, 1.0),
+                            implot.PlotProp.Marker,
+                            implot.Marker.Cross,
+                            implot.PlotProp.MarkerLineColors,
+                            self.colors
+                        )
+                    )
                 elif self.plotMode == 1:
                     size = 10
                     if self.lastUpate > self.updatePeriod:
@@ -81,7 +101,7 @@ class State:
                         self.plotIdx = (self.plotIdx + 1) % (size * size)
                         self.lastUpate = 0
                     implot.PlotHeatmap(
-                        "DATA",
+                        "Heatmap",
                         self.plotY,
                         size,
                         size,
@@ -91,7 +111,7 @@ class State:
                 elif self.plotMode == 2:
                     size = 200
                     self.t += dt * 0.1
-                    implot.PlotScatterG("DATA", dataGetter, self.t, size)
+                    implot.PlotScatterG("Custom", dataGetter, self.t, size)
                 implot.EndPlot()
         imgui.End()
 

--- a/examples/implot_example.py
+++ b/examples/implot_example.py
@@ -28,6 +28,18 @@ def dataGetter(idx: int, data) -> implot.Point:
     return implot.Point(val, math.sin(val + data))
 
 
+def customScaleForward(value: float, data) -> float:
+    if value <= 0.0:
+        return value
+    return math.log(value, data)
+
+
+def customScaleInverse(value: float, data) -> float:
+    if value <= 0.0:
+        return value
+    return math.pow(data, value)
+
+
 class State:
 
     def __init__(self) -> None:
@@ -71,9 +83,17 @@ class State:
             if implot.BeginPlot("data", imgui.Vec2(500, 500)):
                 if self.plotMode == 0:
                     # The return value from this has to exist until the plot is ended
-                    # implot.SetupAxisFormat(
-                    #     implot.Axis.X1, formatterCallback, "data"
-                    # )
+                    implot.SetupAxisFormat(
+                        implot.Axis.X1, formatterCallback, "data"
+                    )
+
+                    implot.SetupAxisScale(
+                        implot.Axis.X1,
+                        customScaleForward,
+                        customScaleInverse,
+                        3
+                    )
+
                     if self.lastUpate > self.updatePeriod:
                         self.plotY[
                             self.plotIdx

--- a/examples/implot_example.py
+++ b/examples/implot_example.py
@@ -24,7 +24,7 @@ def formatterCallback(val: float, buf: imgui.EditableStrWrapper, userData):
 
 
 def dataGetter(idx: int, data) -> implot.Point:
-    val = idx + 0.1 / math.pi
+    val = idx * 0.1 / math.pi
     return implot.Point(val, math.sin(val + data))
 
 
@@ -65,7 +65,7 @@ class State:
             if imgui.RadioButton("Custom Getter", self.plotMode == 2):
                 self.plotMode = 2
                 implot.SetNextAxesLimits(
-                    -0.1, 200, -1.1, 1.1, cond=implot.Cond.Always
+                    -0.1, 7, -1.3, 1.3, cond=implot.Cond.Always
                 )
 
             if implot.BeginPlot("data", imgui.Vec2(500, 500)):
@@ -110,8 +110,8 @@ class State:
                     )
                 elif self.plotMode == 2:
                     size = 200
-                    self.t += dt * 0.1
-                    implot.PlotScatterG("Custom", dataGetter, self.t, size)
+                    self.t += dt * 0.5
+                    implot.PlotLineG("Custom", dataGetter, self.t, size)
                 implot.EndPlot()
         imgui.End()
 

--- a/examples/implot_example.py
+++ b/examples/implot_example.py
@@ -14,12 +14,18 @@ from imgui_utils.boilerplate import window_mainloop
 
 import imgui.implot as implot
 import imgui
+import math
 
 
 def formatterCallback(val: float, buf: imgui.EditableStrWrapper, userData):
     label = f'{userData} {val}'
     buf.set(label)
     return 0
+
+
+def dataGetter(idx: int, data) -> implot.Point:
+    val = idx + 0.1 / math.pi
+    return implot.Point(val, math.sin(val + data))
 
 
 class State:
@@ -38,6 +44,7 @@ class State:
 
         self.lastUpate = 0
         self.updatePeriod = 0.5
+        self.t = 0
 
     def render(self, dt: float):
         self.lastUpate += dt
@@ -47,6 +54,9 @@ class State:
                 implot.SetNextAxesToFit()
             if imgui.RadioButton("Heatmap", self.plotMode == 1):
                 self.plotMode = 1
+                implot.SetNextAxesToFit()
+            if imgui.RadioButton("Custom Getter", self.plotMode == 2):
+                self.plotMode = 2
                 implot.SetNextAxesToFit()
 
             if implot.BeginPlot("data", imgui.Vec2(500, 500)):
@@ -78,6 +88,10 @@ class State:
                         self.plotMin,
                         self.plotMax
                     )
+                elif self.plotMode == 2:
+                    size = 200
+                    self.t += dt * 0.1
+                    implot.PlotScatterG("DATA", dataGetter, self.t, size)
                 implot.EndPlot()
         imgui.End()
 

--- a/imgui_utils/boilerplate.py
+++ b/imgui_utils/boilerplate.py
@@ -2,7 +2,7 @@
 A basic boilerplate function so you can get up and running fast
 """
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 import platform
 
 import imgui as im
@@ -33,7 +33,7 @@ def window_mainloop(
     opengl_ver_minor=6,
     glsl_version="#version 130",
     clear_color=im.Vec4(0.22, 0.22, 0.22, 1.0),
-    window_icon: Optional[str] = None
+    window_icon: Optional[Union[str, glfw.Image]] = None
 ):
     """
     Create a single window and enter render loop until either the window is closed
@@ -53,14 +53,13 @@ def window_mainloop(
     :param opengl_ver_minor: The openGL minor version
     :param glsl_version: The GLSL version
     :param clear_color: The default background clear color
-    :param window_icon: The path to an image to use as the window icon
+    :param window_icon: The image (or path) to use as the window icon
     """
 
     # set error callback func
     glfw.SetErrorCallback(errorCallback)
     if not glfw.Init():
-        print("Cannot initialize GLFW")
-        return
+        raise RuntimeError("Cannot initialize GLFW")
 
     # create our window
     glfw.WindowHint(glfw.CONTEXT_VERSION_MAJOR, opengl_ver_major)
@@ -79,8 +78,7 @@ def window_mainloop(
 
     window = glfw.CreateWindow(width, height, title)
     if window is None:
-        print("Cannot create GLFW window")
-        return
+        raise RuntimeError("Cannot create GLFW window")
 
     glfw.MakeContextCurrent(window)
     # enable vsync
@@ -88,8 +86,14 @@ def window_mainloop(
 
     # Set window icon
     if window_icon is not None:
-        # Byte data must be RGBA
-        icon = glfw.Image(window_icon)
+        if isinstance(window_icon, str):
+            icon = glfw.Image(window_icon)
+        elif isinstance(window_icon, glfw.Image):
+            icon = window_icon
+        else:
+            raise ValueError(
+                "Invalid type for window_icon, expected str or glfw.Image"
+            )
         glfw.SetWindowIcon(window, [icon])
 
     # Create ImGui context

--- a/py-imgui-redux/inc/bind-imgui/implot-spec.h
+++ b/py-imgui-redux/inc/bind-imgui/implot-spec.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+#include <implot.h>
+
+ImPlotSpec makeSpec(pybind11::tuple args);
+
+inline ImPlotSpec makeSpec(pybind11::object args)
+{
+    return makeSpec(args.cast<py::tuple>());
+}

--- a/py-imgui-redux/inc/binder/list-wrapper.h
+++ b/py-imgui-redux/inc/binder/list-wrapper.h
@@ -3,6 +3,11 @@
 #include <pybind11/pybind11.h>
 #include <stdexcept>
 
+/**
+ * List wrappers are used to return pointers to fixed size arrays
+ * from various functions and allow editting (for non-const)
+ */
+
 template<class T> class ConstListWrapper
 {
 public:

--- a/py-imgui-redux/inc/binder/wraps.h
+++ b/py-imgui-redux/inc/binder/wraps.h
@@ -383,6 +383,12 @@ using StrListPtr = StrList*;
 using Vec2List = ImList<ImVec2>;
 using Vec2ListPtr = Vec2List*;
 
+using Vec4List = ImList<ImVec4>;
+using Vec4ListPtr = Vec4List*;
+
+using ImU32List = ImList<ImU32>;
+using ImU32ListPtr = ImU32List*;
+
 class StrRef : public ImList<char>
 {
 public:

--- a/py-imgui-redux/src/bind-imgui.cpp
+++ b/py-imgui-redux/src/bind-imgui.cpp
@@ -1,12 +1,16 @@
 #include <binder/bind-modules.h>
 #include <binder/wraps.h>
 
+#include <bind-imgui/imgui-modules.h>
+
 PYBIND11_MODULE(imgui, m)
 {
     m.doc() = "DearImGui Framework";
     py::options options;
     //options.disable_function_signatures();
 
+    // Init the vectors first so we can use the list wrappers on them
+    init_imgui_vectors(m);
     init_wraps(m);
 
     // GLFW first so that the Window object is defined

--- a/py-imgui-redux/src/binder/wraps.cpp
+++ b/py-imgui-redux/src/binder/wraps.cpp
@@ -216,6 +216,11 @@ void init_wraps(py::module& m)
         "Vec2List",
         "Thin wrapper over a std::vector<ImVec2>"
     );
+    initList<Vec4List, ImVec4>(
+        m,
+        "Vec4List",
+        "Thin wrapper over a std::vector<ImVec4>"
+    );
 
     py::class_<StrRef>(m, "StrRef", "Thin wrapper over a std::vector<char>")
         .def(

--- a/py-imgui-redux/src/binder/wraps.cpp
+++ b/py-imgui-redux/src/binder/wraps.cpp
@@ -132,9 +132,9 @@ void initMathRef(py::module& m, const char* name, const char* desc, U defaultVal
 }
 
 template<class T, class U>
-void initList(py::module& m, const char* name, const char* desc)
+py::class_<T> initList(py::module& m, const char* name, const char* desc)
 {
-    py::class_<T>(m, name, desc)
+    return py::class_<T>(m, name, desc)
         .def(py::init<std::vector<U>>(), "vals"_a = std::vector<U>())
         .def(py::init<>())
         .def("append", &T::append, "val"_a, "Append a value to the end")
@@ -191,11 +191,13 @@ void init_wraps(py::module& m)
         .def("__bool__", &BoolRef_::toBool);
 
     initList<IntList, int>(m, "IntList", "Thin wrapper over a std::vector<int>");
-    initList<ImU32List, ImU32>(
+    auto u32list = initList<ImU32List, ImU32>(
         m,
         "ImU32List",
         "Thin wrapper over a std::vector<ImU32>"
     );
+    m.add_object("WCharList", u32list);
+
     initList<FloatList, float>(
         m,
         "FloatList",

--- a/py-imgui-redux/src/binder/wraps.cpp
+++ b/py-imgui-redux/src/binder/wraps.cpp
@@ -191,10 +191,10 @@ void init_wraps(py::module& m)
         .def("__bool__", &BoolRef_::toBool);
 
     initList<IntList, int>(m, "IntList", "Thin wrapper over a std::vector<int>");
-    initList<WCharList, ImWchar>(
+    initList<ImU32List, ImU32>(
         m,
-        "WCharList",
-        "Thin wrapper over a std::vector<ImWchar>"
+        "ImU32List",
+        "Thin wrapper over a std::vector<ImU32>"
     );
     initList<FloatList, float>(
         m,

--- a/py-imgui-redux/src/imgui-core/bind-imgui-core.cpp
+++ b/py-imgui-redux/src/imgui-core/bind-imgui-core.cpp
@@ -4,7 +4,6 @@
 void init_core_imgui(py::module& m)
 {
     // Structs
-    init_imgui_vectors(m);
     init_imgui_structs(m);
     // Enums
     init_imgui_enums(m);

--- a/py-imgui-redux/src/imgui-core/modules/stacks.cpp
+++ b/py-imgui-redux/src/imgui-core/modules/stacks.cpp
@@ -3,7 +3,7 @@
 void init_stacks(py::module& m)
 {
     // Parameter Stacks (Shared)
-    m.def(IMFUNC(PushFont), "font"_a.none(true), "font_size_base_unscaled"_a);
+    m.def(IMFUNC(PushFont), "font"_a, "font_size_base_unscaled"_a);
     QUICK(PopFont);
     m.def(
         "PushStyleColor",

--- a/py-imgui-redux/src/imgui-core/modules/stacks.cpp
+++ b/py-imgui-redux/src/imgui-core/modules/stacks.cpp
@@ -3,7 +3,7 @@
 void init_stacks(py::module& m)
 {
     // Parameter Stacks (Shared)
-    m.def(IMFUNC(PushFont), "font"_a, "font_size_base_unscaled"_a);
+    m.def(IMFUNC(PushFont), "font"_a.none(true), "font_size_base_unscaled"_a);
     QUICK(PopFont);
     m.def(
         "PushStyleColor",

--- a/py-imgui-redux/src/implot/modules/implot-colormap.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-colormap.cpp
@@ -16,9 +16,31 @@ void init_colormaps(py::module& m)
     );
     m.def(
         "AddColorMap",
+        [](const char* name, Vec4ListPtr cols, bool qual)
+        {
+            return ImPlot::AddColormap(name, cols->data(), cols->size(), qual);
+        },
+        "name"_a,
+        "cols"_a,
+        "qual"_a = true
+    );
+
+    m.def(
+        "AddColorMap",
         [](const char* name, arr<ImU32> cols, bool qual)
         {
             return ImPlot::AddColormap(name, cols.data(), cols.size(), qual);
+        },
+        "name"_a,
+        "cols"_a,
+        "qual"_a = true
+    );
+
+    m.def(
+        "AddColorMap",
+        [](const char* name, ImU32ListPtr cols, bool qual)
+        {
+            return ImPlot::AddColormap(name, cols->data(), cols->size(), qual);
         },
         "name"_a,
         "cols"_a,

--- a/py-imgui-redux/src/implot/modules/implot-context.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-context.cpp
@@ -28,7 +28,7 @@ void init_implot_context(py::module& m)
         py::arg_v("size", ImVec2(-1, 0), "Vec2(-1, 0)"),
         "flags"_a = 0
     );
-    QUICK(EndPlot);
+    // EndPlot is defined in implot-setup-funcs so we can clear the formatter callbacks
 
     m.def(
         "BeginSubplots",

--- a/py-imgui-redux/src/implot/modules/implot-enums.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-enums.cpp
@@ -11,6 +11,25 @@ void init_implot_enums(py::module& m)
         .VALUE(Im, Axis, Y2)
         .VALUE(Im, Axis, Y3);
 
+    ENUM(Im, PlotProp)
+        .VALUE(Im, PlotProp, LineColor)
+        .VALUE(Im, PlotProp, LineColors)
+        .VALUE(Im, PlotProp, LineWeight)
+        .VALUE(Im, PlotProp, FillColor)
+        .VALUE(Im, PlotProp, FillColors)
+        .VALUE(Im, PlotProp, FillAlpha)
+        .VALUE(Im, PlotProp, Marker)
+        .VALUE(Im, PlotProp, MarkerSize)
+        .VALUE(Im, PlotProp, MarkerSizes)
+        .VALUE(Im, PlotProp, MarkerLineColor)
+        .VALUE(Im, PlotProp, MarkerLineColors)
+        .VALUE(Im, PlotProp, MarkerFillColor)
+        .VALUE(Im, PlotProp, MarkerFillColors)
+        .VALUE(Im, PlotProp, Size)
+        .VALUE(Im, PlotProp, Offset)
+        .VALUE(Im, PlotProp, Stride)
+        .VALUE(Im, PlotProp, Flags);
+
     ENUM(Im, PlotFlags)
         .RAW_VALUE(None_, ImPlotFlags_None)
         .VALUE(Im, PlotFlags, NoTitle)
@@ -68,7 +87,8 @@ void init_implot_enums(py::module& m)
         .VALUE(ImPlot, LegendFlags, NoMenus)
         .VALUE(ImPlot, LegendFlags, Outside)
         .VALUE(ImPlot, LegendFlags, Horizontal)
-        .VALUE(ImPlot, LegendFlags, Sort);
+        .VALUE(ImPlot, LegendFlags, Sort)
+        .VALUE(ImPlot, LegendFlags, Reverse);
 
     ENUM(ImPlot, MouseTextFlags)
         .RAW_VALUE(None_, ImPlotMouseTextFlags_None)
@@ -106,6 +126,12 @@ void init_implot_enums(py::module& m)
         .RAW_VALUE(None_, ImPlotScatterFlags_None)
         .VALUE(ImPlot, ScatterFlags, NoClip);
 
+    ENUM(ImPlot, BubblesFlags).RAW_VALUE(None_, ImPlotBubblesFlags_None);
+
+    ENUM(ImPlot, PolygonFlags)
+        .RAW_VALUE(None_, ImPlotPolygonFlags_None)
+        .VALUE(ImPlot, PolygonFlags, Concave);
+
     ENUM(ImPlot, StairsFlags)
         .RAW_VALUE(None_, ImPlotStairsFlags_None)
         .VALUE(ImPlot, StairsFlags, PreStep)
@@ -138,7 +164,8 @@ void init_implot_enums(py::module& m)
         .RAW_VALUE(None_, ImPlotPieChartFlags_None)
         .VALUE(ImPlot, PieChartFlags, Normalize)
         .VALUE(ImPlot, PieChartFlags, IgnoreHidden)
-        .VALUE(ImPlot, PieChartFlags, Exploding);
+        .VALUE(ImPlot, PieChartFlags, Exploding)
+        .VALUE(ImPlot, PieChartFlags, NoSliceBorder);
 
     ENUM(ImPlot, HeatmapFlags)
         .RAW_VALUE(None_, ImPlotHeatmapFlags_None)
@@ -168,11 +195,6 @@ void init_implot_enums(py::module& m)
         .VALUE(ImPlot, Cond, Once);
 
     ENUM(ImPlot, Col)
-        .VALUE(ImPlot, Col, Line)
-        .VALUE(ImPlot, Col, Fill)
-        .VALUE(ImPlot, Col, MarkerOutline)
-        .VALUE(ImPlot, Col, MarkerFill)
-        .VALUE(ImPlot, Col, ErrorBar)
         .VALUE(ImPlot, Col, FrameBg)
         .VALUE(ImPlot, Col, PlotBg)
         .VALUE(ImPlot, Col, PlotBorder)
@@ -191,15 +213,8 @@ void init_implot_enums(py::module& m)
         .VALUE(ImPlot, Col, Crosshairs);
 
     ENUM(ImPlot, StyleVar)
-        .VALUE(ImPlot, StyleVar, LineWeight)
-        .VALUE(ImPlot, StyleVar, Marker)
-        .VALUE(ImPlot, StyleVar, MarkerSize)
-        .VALUE(ImPlot, StyleVar, MarkerWeight)
-        .VALUE(ImPlot, StyleVar, FillAlpha)
-        .VALUE(ImPlot, StyleVar, ErrorBarSize)
-        .VALUE(ImPlot, StyleVar, ErrorBarWeight)
-        .VALUE(ImPlot, StyleVar, DigitalBitHeight)
-        .VALUE(ImPlot, StyleVar, DigitalBitGap)
+        .VALUE(ImPlot, StyleVar, PlotDefaultSize)
+        .VALUE(ImPlot, StyleVar, PlotMinSize)
         .VALUE(ImPlot, StyleVar, PlotBorderSize)
         .VALUE(ImPlot, StyleVar, MinorAlpha)
         .VALUE(ImPlot, StyleVar, MajorTickLen)
@@ -216,8 +231,8 @@ void init_implot_enums(py::module& m)
         .VALUE(ImPlot, StyleVar, MousePosPadding)
         .VALUE(ImPlot, StyleVar, AnnotationPadding)
         .VALUE(ImPlot, StyleVar, FitPadding)
-        .VALUE(ImPlot, StyleVar, PlotDefaultSize)
-        .VALUE(ImPlot, StyleVar, PlotMinSize);
+        .VALUE(ImPlot, StyleVar, DigitalPadding)
+        .VALUE(ImPlot, StyleVar, DigitalSpacing);
 
     ENUM(ImPlot, Scale)
         .VALUE(ImPlot, Scale, Linear)
@@ -227,6 +242,7 @@ void init_implot_enums(py::module& m)
 
     ENUM(ImPlot, Marker)
         .RAW_VALUE(None_, ImPlotMarker_None)
+        .VALUE(ImPlot, Marker, Auto)
         .VALUE(ImPlot, Marker, Circle)
         .VALUE(ImPlot, Marker, Square)
         .VALUE(ImPlot, Marker, Diamond)

--- a/py-imgui-redux/src/implot/modules/implot-plotting.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-plotting.cpp
@@ -3,6 +3,22 @@
 #include <binder/numpy.h>
 #include <binder/wraps.h>
 
+#include <pybind11/functional.h>
+
+using GetterCallback = std::function<ImPlotPoint(int, py::object)>;
+
+struct GetterCallbackData
+{
+    GetterCallback callback;
+    py::object userdata;
+};
+
+ImPlotPoint getterCallbackFunc(int index, void* userdata)
+{
+    auto* data = static_cast<GetterCallbackData*>(userdata);
+    return data->callback(index, data->userdata);
+}
+
 template<typename T> void initWrapperPlotting(py::module& m)
 {
     m.def(
@@ -11,8 +27,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            T values,
            double xscale,
            double xstart,
-           ImPlotLineFlags flags,
-           int offset)
+           const ImPlotSpec& spec)
         {
             ImPlot::PlotLine(
                 label_id,
@@ -20,40 +35,48 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 values->size(),
                 xscale,
                 xstart,
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
         "values"_a,
         "xscale"_a = 1,
         "xstart"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
         "PlotLine",
-        [](const char* label_id, T xs, T ys, int flags, int offset)
+        [](const char* label_id, T xs, T ys, const ImPlotSpec& spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y)");
             }
-            ImPlot::PlotLine(
-                label_id,
-                xs->data(),
-                ys->data(),
-                xs->size(),
-                flags,
-                offset
-            );
+            ImPlot::PlotLine(label_id, xs->data(), ys->data(), xs->size(), spec);
         },
         "label_id"_a,
         "xs"_a,
         "ys"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
+
+    m.def(
+        "PlotLineG",
+        [](const char* label_id,
+           GetterCallback getter,
+           py::object data,
+           int count,
+           const ImPlotSpec& spec)
+        {
+            GetterCallbackData userdata{getter, data};
+            ImPlot::PlotLineG(label_id, getterCallbackFunc, &userdata, count, spec);
+        },
+        "label_id"_a,
+        "getter"_a.none(false),
+        "data"_a,
+        "count"_a,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
@@ -62,8 +85,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            T values,
            double xscale,
            double xstart,
-           ImPlotScatterFlags flags,
-           int offset)
+           const ImPlotSpec& spec)
         {
             ImPlot::PlotScatter(
                 label_id,
@@ -71,40 +93,125 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 values->size(),
                 xscale,
                 xstart,
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
         "values"_a,
         "xscale"_a = 1,
         "xstart"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
         "PlotScatter",
-        [](const char* label_id, T xs, T ys, ImPlotScatterFlags flags, int offset)
+        [](const char* label_id, T xs, T ys, const ImPlotSpec& spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y)");
             }
-            ImPlot::PlotScatter(
+            ImPlot::PlotScatter(label_id, xs->data(), ys->data(), xs->size(), spec);
+        },
+        "label_id"_a,
+        "xs"_a,
+        "ys"_a,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
+
+    m.def(
+        "PlotScatterG",
+        [](const char* label_id,
+           GetterCallback getter,
+           py::object data,
+           int count,
+           const ImPlotSpec& spec)
+        {
+            GetterCallbackData userdata{getter, data};
+            ImPlot::PlotScatterG(
+                label_id,
+                getterCallbackFunc,
+                &userdata,
+                count,
+                spec
+            );
+        },
+        "label_id"_a,
+        "getter"_a.none(false),
+        "data"_a,
+        "count"_a,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
+
+    m.def(
+        "PlotBubbles",
+        [](const char* label_id,
+           T values,
+           T sizes,
+           double xscale,
+           double xstart,
+           const ImPlotSpec& spec)
+        {
+            if(values->size() != sizes->size())
+            {
+                throw py::value_error("len(values) != len(sizes)");
+            }
+            ImPlot::PlotBubbles(
+                label_id,
+                values->data(),
+                sizes->data(),
+                values->size(),
+                xscale,
+                xstart,
+                spec
+            );
+        },
+        "label_id"_a,
+        "values"_a,
+        "szs"_a,
+        "xscale"_a = 1,
+        "xstart"_a = 0,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
+
+    m.def(
+        "PlotBubbles",
+        [](const char* label_id, T xs, T ys, T sizes, const ImPlotSpec& spec)
+        {
+            if(xs->size() != ys->size())
+            {
+                throw py::value_error("len(x) != len(y)");
+            }
+            ImPlot::PlotBubbles(
                 label_id,
                 xs->data(),
                 ys->data(),
+                sizes->data(),
                 xs->size(),
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
         "xs"_a,
         "ys"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
+        "szs"_a,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
+
+    m.def(
+        "PlotPolygon",
+        [](const char* label_id, T xs, T ys, const ImPlotSpec& spec)
+        {
+            if(xs->size() != ys->size())
+            {
+                throw py::value_error("len(x) != len(y)");
+            }
+            ImPlot::PlotPolygon(label_id, xs->data(), ys->data(), xs->size(), spec);
+        },
+        "label_id"_a,
+        "xs"_a,
+        "ys"_a,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
@@ -113,8 +220,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            T values,
            double xscale,
            double xstart,
-           ImPlotStairsFlags flags,
-           int offset)
+           const ImPlotSpec& spec)
         {
             ImPlot::PlotStairs(
                 label_id,
@@ -122,40 +228,54 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 values->size(),
                 xscale,
                 xstart,
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
         "values"_a,
         "xscale"_a = 1,
         "xstart"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
         "PlotStairs",
-        [](const char* label_id, T xs, T ys, ImPlotStairsFlags flags, int offset)
+        [](const char* label_id, T xs, T ys, const ImPlotSpec& spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y)");
             }
-            ImPlot::PlotStairs(
-                label_id,
-                xs->data(),
-                ys->data(),
-                xs->size(),
-                flags,
-                offset
-            );
+            ImPlot::PlotStairs(label_id, xs->data(), ys->data(), xs->size(), spec);
         },
         "label_id"_a,
         "xs"_a,
         "ys"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
+
+    m.def(
+        "PlotStairsG",
+        [](const char* label_id,
+           GetterCallback getter,
+           py::object data,
+           int count,
+           const ImPlotSpec& spec)
+        {
+            GetterCallbackData userdata{getter, data};
+            ImPlot::PlotStairsG(
+                label_id,
+                getterCallbackFunc,
+                &userdata,
+                count,
+                spec
+            );
+        },
+        "label_id"_a,
+        "getter"_a.none(false),
+        "data"_a,
+        "count"_a,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
@@ -165,8 +285,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            double yref,
            double xscale,
            double xstart,
-           ImPlotShadedFlags flags,
-           int offset)
+           const ImPlotSpec& spec)
         {
             ImPlot::PlotShaded(
                 label_id,
@@ -175,8 +294,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 yref,
                 xscale,
                 xstart,
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
@@ -184,18 +302,12 @@ template<typename T> void initWrapperPlotting(py::module& m)
         "yref"_a = 0,
         "xscale"_a = 1,
         "xstart"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
         "PlotShaded",
-        [](const char* label_id,
-           T xs,
-           T ys,
-           double yref,
-           ImPlotShadedFlags flags,
-           int offset)
+        [](const char* label_id, T xs, T ys, double yref, const ImPlotSpec& spec)
         {
             if(xs->size() != ys->size())
             {
@@ -207,26 +319,19 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 ys->data(),
                 xs->size(),
                 yref,
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
         "xs"_a,
         "ys"_a,
         "yref"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
         "PlotShaded",
-        [](const char* label_id,
-           T xs,
-           T ys1,
-           T ys2,
-           ImPlotShadedFlags flags,
-           int offset)
+        [](const char* label_id, T xs, T ys1, T ys2, const ImPlotSpec& spec)
         {
             if(xs->size() != ys1->size() || xs->size() != ys2->size())
             {
@@ -238,16 +343,45 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 ys1->data(),
                 ys2->data(),
                 xs->size(),
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
         "xs"_a,
         "ys1"_a,
         "ys2"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
+
+    m.def(
+        "PlotShadedG",
+        [](const char* label_id,
+           GetterCallback getter1,
+           py::object data1,
+           GetterCallback getter2,
+           py::object data2,
+           int count,
+           const ImPlotSpec& spec)
+        {
+            GetterCallbackData cbdata1{getter1, data1};
+            GetterCallbackData cbdata2{getter2, data2};
+            ImPlot::PlotShadedG(
+                label_id,
+                getterCallbackFunc,
+                &cbdata1,
+                getterCallbackFunc,
+                &cbdata2,
+                count,
+                spec
+            );
+        },
+        "label_id"_a,
+        "getter1"_a.none(false),
+        "data1"_a,
+        "getter2"_a.none(false),
+        "data2"_a,
+        "count"_a,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
@@ -256,8 +390,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            T values,
            double bar_size,
            double shift,
-           ImPlotBarsFlags flags,
-           int offset)
+           const ImPlotSpec& spec)
         {
             ImPlot::PlotBars(
                 label_id,
@@ -265,26 +398,19 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 values->size(),
                 bar_size,
                 shift,
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
         "values"_a,
         "bar_size"_a = 0.67,
         "shift"_a = 0.0,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
         "PlotBars",
-        [](const char* label_id,
-           T xs,
-           T ys,
-           double bar_size,
-           ImPlotBarsFlags flags,
-           int offset)
+        [](const char* label_id, T xs, T ys, double bar_size, const ImPlotSpec& spec)
         {
             if(xs->size() != ys->size())
             {
@@ -296,16 +422,41 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 ys->data(),
                 xs->size(),
                 bar_size,
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
         "xs"_a,
         "ys"_a,
         "bar_size"_a = 0.67,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
+
+    m.def(
+        "PlotBarsG",
+        [](const char* label_id,
+           GetterCallback getter,
+           py::object data,
+           int count,
+           double bar_size,
+           const ImPlotSpec& spec)
+        {
+            GetterCallbackData userdata{getter, data};
+            ImPlot::PlotBarsG(
+                label_id,
+                getterCallbackFunc,
+                &userdata,
+                count,
+                bar_size,
+                spec
+            );
+        },
+        "label_id"_a,
+        "getter"_a.none(false),
+        "data"_a,
+        "count"_a,
+        "bar_size"_a,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
@@ -316,7 +467,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            int group_count,
            double group_size,
            double shift,
-           ImPlotBarGroupsFlags flags)
+           const ImPlotSpec& spec)
         {
             if(labels->size() != item_count)
             {
@@ -334,7 +485,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 group_count,
                 group_size,
                 shift,
-                flags
+                spec
             );
         },
         "labels"_a,
@@ -343,17 +494,12 @@ template<typename T> void initWrapperPlotting(py::module& m)
         "group_count"_a,
         "group_size"_a = 0.67,
         "shift"_a = 0.0,
-        "flags"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
         "PlotErrorBars",
-        [](const char* label_id,
-           T xs,
-           T ys,
-           T err,
-           ImPlotErrorBarsFlags flags,
-           int offset)
+        [](const char* label_id, T xs, T ys, T err, const ImPlotSpec& spec)
         {
             if(xs->size() != ys->size() || xs->size() != err->size())
             {
@@ -366,27 +512,19 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 ys->data(),
                 err->data(),
                 xs->size(),
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
         "xs"_a,
         "ys"_a,
         "err"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
         "PlotErrorBars",
-        [](const char* label_id,
-           T xs,
-           T ys,
-           T neg,
-           T pos,
-           ImPlotErrorBarsFlags flags,
-           int offset)
+        [](const char* label_id, T xs, T ys, T neg, T pos, const ImPlotSpec& spec)
         {
             if(xs->size() != ys->size() || xs->size() != neg->size()
                || xs->size() != pos->size())
@@ -403,8 +541,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 neg->data(),
                 pos->data(),
                 xs->size(),
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
@@ -412,8 +549,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
         "ys"_a,
         "neg"_a,
         "pos"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
@@ -423,8 +559,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            int ref,
            double scale,
            double start,
-           ImPlotStemsFlags flags,
-           int offset)
+           const ImPlotSpec& spec)
         {
             ImPlot::PlotStems(
                 label_id,
@@ -433,8 +568,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 ref,
                 scale,
                 start,
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
@@ -442,17 +576,12 @@ template<typename T> void initWrapperPlotting(py::module& m)
         "ref"_a = 0,
         "scale"_a = 1,
         "start"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
+
     m.def(
         "PlotStems",
-        [](const char* label_id,
-           T xs,
-           T ys,
-           int ref,
-           ImPlotStemsFlags flags,
-           int offset)
+        [](const char* label_id, T xs, T ys, int ref, const ImPlotSpec& spec)
         {
             if(xs->size() != ys->size())
             {
@@ -464,35 +593,28 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 ys->data(),
                 xs->size(),
                 ref,
-                flags,
-                offset
+                spec
             );
         },
         "label_id"_a,
         "xs"_a,
         "ys"_a,
         "ref"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
         "PlotInfLines",
-        [](const char* label_id, T values, ImPlotInfLinesFlags flags, int offset)
+        [](const char* label_id, T values, const ImPlotSpec& spec)
         {
-            ImPlot::PlotInfLines(
-                label_id,
-                values->data(),
-                values->size(),
-                flags,
-                offset
-            );
+            ImPlot::PlotInfLines(label_id, values->data(), values->size(), spec);
         },
         "label_id"_a,
         "values"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
+
+    // TODO PlotPieChart with formatter?
 
     m.def(
         "PlotPieChart",
@@ -503,7 +625,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            double radius,
            const char* label_fmt,
            double angle0,
-           ImPlotPieChartFlags flags)
+           const ImPlotSpec& spec)
         {
             if(label_ids->size() != values->size())
             {
@@ -518,7 +640,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 radius,
                 label_fmt,
                 angle0,
-                flags
+                spec
             );
         },
         "label_ids"_a,
@@ -528,7 +650,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
         "radius"_a,
         "label_fmt"_a = "%.1f",
         "angle0"_a = 90,
-        "flags"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
@@ -542,7 +664,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            const char* label_fmt,
            const ImPlotPoint& bounds_min,
            const ImPlotPoint& bounds_max,
-           ImPlotHeatmapFlags flags)
+           const ImPlotSpec& spec)
         {
             if(values->size() < rows * cols)
             {
@@ -559,7 +681,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 label_fmt,
                 bounds_min,
                 bounds_max,
-                flags
+                spec
             );
         },
         "label_id"_a,
@@ -571,7 +693,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
         "label_fmt"_a = "%.1f",
         py::arg_v("bounds_min", ImPlotPoint(0, 0), "Point(0, 0)"),
         py::arg_v("bounds_max", ImPlotPoint(1, 1), "Point(1, 1)"),
-        "flags"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
@@ -581,7 +703,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            int bins,
            double bar_scale,
            ImPlotRange range,
-           ImPlotHistogramFlags flags)
+           const ImPlotSpec& spec)
         {
             ImPlot::PlotHistogram(
                 label_id,
@@ -590,7 +712,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 bins,
                 bar_scale,
                 range,
-                flags
+                spec
             );
         },
         "label_id"_a,
@@ -598,7 +720,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
         "bins"_a = (int)ImPlotBin_Sturges,
         "bar_scale"_a = 1.0,
         py::arg_v("range", ImPlotRange(), "Range(0, 0)"),
-        "flags"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
@@ -609,7 +731,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            int x_bins,
            int y_bins,
            ImPlotRect range,
-           ImPlotHistogramFlags flags)
+           const ImPlotSpec& spec)
         {
             if(xs->size() != ys->size())
             {
@@ -623,7 +745,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 x_bins,
                 y_bins,
                 range,
-                flags
+                spec
             );
         },
         "label_id"_a,
@@ -632,32 +754,48 @@ template<typename T> void initWrapperPlotting(py::module& m)
         "x_bins"_a = (int)ImPlotBin_Sturges,
         "y_bins"_a = (int)ImPlotBin_Sturges,
         py::arg_v("range", ImPlotRect(), "Rect(0, 0)"),
-        "flags"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
         "PlotDigital",
-        [](const char* label_id, T xs, T ys, ImPlotDigitalFlags flags, int offset)
+        [](const char* label_id, T xs, T ys, const ImPlotSpec& spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(xs) != len(ys)");
             }
 
-            ImPlot::PlotDigital(
-                label_id,
-                xs->data(),
-                ys->data(),
-                xs->size(),
-                flags,
-                offset
-            );
+            ImPlot::PlotDigital(label_id, xs->data(), ys->data(), xs->size(), spec);
         },
         "label_id"_a,
         "xs"_a,
         "ys"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
+
+    m.def(
+        "PlotDigitalG",
+        [](const char* label_id,
+           GetterCallback getter,
+           py::object data,
+           int count,
+           const ImPlotSpec& spec)
+        {
+            GetterCallbackData userdata{getter, data};
+            ImPlot::PlotDigitalG(
+                label_id,
+                getterCallbackFunc,
+                &userdata,
+                count,
+                spec
+            );
+        },
+        "label_id"_a,
+        "getter"_a.none(false),
+        "data"_a,
+        "count"_a,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 }
 
@@ -665,680 +803,7 @@ void init_plotting(py::module& m)
 {
     initWrapperPlotting<DoubleListPtr>(m);
     initWrapperPlotting<IntListPtr>(m);
-
-    m.def(
-        "PlotLine",
-        [](const char* label_id,
-           arr<double> values,
-           double xscale,
-           double xstart,
-           ImPlotLineFlags flags,
-           int offset)
-        {
-            ImPlot::PlotLine(
-                label_id,
-                values.data(),
-                values.size(),
-                xscale,
-                xstart,
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "values"_a,
-        "xscale"_a = 1,
-        "xstart"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotLine",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys,
-           int flags,
-           int offset)
-        {
-            if(xs.size() != ys.size())
-            {
-                throw py::value_error("len(x) != len(y)");
-            }
-            ImPlot::PlotLine(
-                label_id,
-                xs.data(),
-                ys.data(),
-                xs.size(),
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotScatter",
-        [](const char* label_id,
-           arr<double> values,
-           double xscale,
-           double xstart,
-           ImPlotScatterFlags flags,
-           int offset)
-        {
-            ImPlot::PlotScatter(
-                label_id,
-                values.data(),
-                values.size(),
-                xscale,
-                xstart,
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "values"_a,
-        "xscale"_a = 1,
-        "xstart"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotScatter",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys,
-           ImPlotScatterFlags flags,
-           int offset)
-        {
-            if(xs.size() != ys.size())
-            {
-                throw py::value_error("len(x) != len(y)");
-            }
-            ImPlot::PlotScatter(
-                label_id,
-                xs.data(),
-                ys.data(),
-                xs.size(),
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotStairs",
-        [](const char* label_id,
-           arr<double> values,
-           double xscale,
-           double xstart,
-           ImPlotStairsFlags flags,
-           int offset)
-        {
-            ImPlot::PlotStairs(
-                label_id,
-                values.data(),
-                values.size(),
-                xscale,
-                xstart,
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "values"_a,
-        "xscale"_a = 1,
-        "xstart"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotStairs",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys,
-           ImPlotStairsFlags flags,
-           int offset)
-        {
-            if(xs.size() != ys.size())
-            {
-                throw py::value_error("len(x) != len(y)");
-            }
-            ImPlot::PlotStairs(
-                label_id,
-                xs.data(),
-                ys.data(),
-                xs.size(),
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotShaded",
-        [](const char* label_id,
-           arr<double> values,
-           double yref,
-           double xscale,
-           double xstart,
-           ImPlotShadedFlags flags,
-           int offset)
-        {
-            ImPlot::PlotShaded(
-                label_id,
-                values.data(),
-                values.size(),
-                yref,
-                xscale,
-                xstart,
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "values"_a,
-        "yref"_a = 0,
-        "xscale"_a = 1,
-        "xstart"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotShaded",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys,
-           double yref,
-           ImPlotShadedFlags flags,
-           int offset)
-        {
-            if(xs.size() != ys.size())
-            {
-                throw py::value_error("len(x) != len(y)");
-            }
-            ImPlot::PlotShaded(
-                label_id,
-                xs.data(),
-                ys.data(),
-                xs.size(),
-                yref,
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys"_a,
-        "yref"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotShaded",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys1,
-           arr<double> ys2,
-           ImPlotShadedFlags flags,
-           int offset)
-        {
-            if(xs.size() != ys1.size() || xs.size() != ys2.size())
-            {
-                throw py::value_error("len(x) != len(y1) != len(y2)");
-            }
-            ImPlot::PlotShaded(
-                label_id,
-                xs.data(),
-                ys1.data(),
-                ys2.data(),
-                xs.size(),
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys1"_a,
-        "ys2"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotBars",
-        [](const char* label_id,
-           arr<double> values,
-           double bar_size,
-           double shift,
-           ImPlotBarsFlags flags,
-           int offset)
-        {
-            ImPlot::PlotBars(
-                label_id,
-                values.data(),
-                values.size(),
-                bar_size,
-                shift,
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "values"_a,
-        "bar_size"_a = 0.67,
-        "shift"_a = 0.0,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotBars",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys,
-           double bar_size,
-           ImPlotBarsFlags flags,
-           int offset)
-        {
-            if(xs.size() != ys.size())
-            {
-                throw py::value_error("len(x) != len(y1)");
-            }
-            ImPlot::PlotBars(
-                label_id,
-                xs.data(),
-                ys.data(),
-                xs.size(),
-                bar_size,
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys"_a,
-        "bar_size"_a = 0.67,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotBarGroups",
-        [](arr<const char*> labels,
-           arr<double> values,
-           int item_count,
-           int group_count,
-           double group_size,
-           double shift,
-           ImPlotBarGroupsFlags flags)
-        {
-            if(labels.size() != item_count)
-            {
-                throw py::value_error("len(labels) != item_count");
-            }
-            if(values.size() != item_count * group_size)
-            {
-                throw py::value_error("len(values) != item_count * group_count");
-            }
-
-            ImPlot::PlotBarGroups(
-                labels.data(),
-                values.data(),
-                item_count,
-                group_count,
-                group_size,
-                shift,
-                flags
-            );
-        },
-        "labels"_a,
-        "values"_a,
-        "item_count"_a,
-        "group_count"_a,
-        "group_size"_a = 0.67,
-        "shift"_a = 0.0,
-        "flags"_a = 0
-    );
-
-    m.def(
-        "PlotErrorBars",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys,
-           arr<double> err,
-           ImPlotErrorBarsFlags flags,
-           int offset)
-        {
-            if(xs.size() != ys.size() || xs.size() != err.size())
-            {
-                throw py::value_error("len(xs) != len(ys) != len(err)");
-            }
-
-            ImPlot::PlotErrorBars(
-                label_id,
-                xs.data(),
-                ys.data(),
-                err.data(),
-                xs.size(),
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys"_a,
-        "err"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotErrorBars",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys,
-           arr<double> neg,
-           arr<double> pos,
-           ImPlotErrorBarsFlags flags,
-           int offset)
-        {
-            if(xs.size() != ys.size() || xs.size() != neg.size()
-               || xs.size() != pos.size())
-            {
-                throw py::value_error(
-                    "len(xs) != len(ys) != len(neg) != len(pos)"
-                );
-            }
-
-            ImPlot::PlotErrorBars(
-                label_id,
-                xs.data(),
-                ys.data(),
-                neg.data(),
-                pos.data(),
-                xs.size(),
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys"_a,
-        "neg"_a,
-        "pos"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotStems",
-        [](const char* label_id,
-           arr<double> values,
-           int ref,
-           double scale,
-           double start,
-           ImPlotStemsFlags flags,
-           int offset)
-        {
-            ImPlot::PlotStems(
-                label_id,
-                values.data(),
-                values.size(),
-                ref,
-                scale,
-                start,
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "values"_a,
-        "ref"_a = 0,
-        "scale"_a = 1,
-        "start"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-    m.def(
-        "PlotStems",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys,
-           int ref,
-           ImPlotStemsFlags flags,
-           int offset)
-        {
-            if(xs.size() != ys.size())
-            {
-                throw py::value_error("len(x) != len(y1)");
-            }
-            ImPlot::PlotStems(
-                label_id,
-                xs.data(),
-                ys.data(),
-                xs.size(),
-                ref,
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys"_a,
-        "ref"_a = 0,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotInfLines",
-        [](const char* label_id,
-           arr<double> values,
-           ImPlotInfLinesFlags flags,
-           int offset)
-        {
-            ImPlot::PlotInfLines(
-                label_id,
-                values.data(),
-                values.size(),
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "values"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
-
-    m.def(
-        "PlotPieChart",
-        [](arr<const char*> label_ids,
-           arr<double> values,
-           double x,
-           double y,
-           double radius,
-           const char* label_fmt,
-           double angle0,
-           ImPlotPieChartFlags flags)
-        {
-            if(label_ids.size() != values.size())
-            {
-                throw py::value_error("len(label_ids) != len(values)");
-            }
-            ImPlot::PlotPieChart(
-                label_ids.data(),
-                values.data(),
-                label_ids.size(),
-                x,
-                y,
-                radius,
-                label_fmt,
-                angle0,
-                flags
-            );
-        },
-        "label_ids"_a,
-        "values"_a,
-        "x"_a,
-        "y"_a,
-        "radius"_a,
-        "label_fmt"_a = "%.1f",
-        "angle0"_a = 90,
-        "flags"_a = 0
-    );
-
-    m.def(
-        "PlotHeatmap",
-        [](const char* label_id,
-           arr<double> values,
-           int rows,
-           int cols,
-           double scale_min,
-           double scale_max,
-           const char* label_fmt,
-           const ImPlotPoint& bounds_min,
-           const ImPlotPoint& bounds_max,
-           ImPlotHeatmapFlags flags)
-        {
-            if(values.size() < rows * cols)
-            {
-                throw py::value_error("len(values) > rows * cols");
-            }
-
-            ImPlot::PlotHeatmap(
-                label_id,
-                values.data(),
-                rows,
-                cols,
-                scale_min,
-                scale_max,
-                label_fmt,
-                bounds_min,
-                bounds_max,
-                flags
-            );
-        },
-        "label_id"_a,
-        "values"_a,
-        "rows"_a,
-        "cols"_a,
-        "scale_min"_a = 0,
-        "scale_max"_a = 0,
-        "label_fmt"_a = "%.1f",
-        py::arg_v("bounds_min", ImPlotPoint(0, 0), "Point(0, 0)"),
-        py::arg_v("bounds_max", ImPlotPoint(1, 1), "Point(1, 1)"),
-        "flags"_a = 0
-    );
-
-    m.def(
-        "PlotHistogram",
-        [](const char* label_id,
-           arr<double> values,
-           int bins,
-           double bar_scale,
-           ImPlotRange range,
-           ImPlotHistogramFlags flags)
-        {
-            ImPlot::PlotHistogram(
-                label_id,
-                values.data(),
-                values.size(),
-                bins,
-                bar_scale,
-                range,
-                flags
-            );
-        },
-        "label_id"_a,
-        "values"_a,
-        "bins"_a = (int)ImPlotBin_Sturges,
-        "bar_scale"_a = 1.0,
-        py::arg_v("range", ImPlotRange(), "Range(0, 0)"),
-        "flags"_a = 0
-    );
-
-    m.def(
-        "PlotHistogram2D",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys,
-           int x_bins,
-           int y_bins,
-           ImPlotRect range,
-           ImPlotHistogramFlags flags)
-        {
-            if(xs.size() != ys.size())
-            {
-                throw py::value_error("len(xs) != len(ys)");
-            }
-            ImPlot::PlotHistogram2D(
-                label_id,
-                xs.data(),
-                ys.data(),
-                xs.size(),
-                x_bins,
-                y_bins,
-                range,
-                flags
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys"_a,
-        "x_bins"_a = (int)ImPlotBin_Sturges,
-        "y_bins"_a = (int)ImPlotBin_Sturges,
-        py::arg_v("range", ImPlotRect(), "Rect(0, 0)"),
-        "flags"_a = 0
-    );
-
-    m.def(
-        "PlotDigital",
-        [](const char* label_id,
-           arr<double> xs,
-           arr<double> ys,
-           ImPlotDigitalFlags flags,
-           int offset)
-        {
-            if(xs.size() != ys.size())
-            {
-                throw py::value_error("len(xs) != len(ys)");
-            }
-
-            ImPlot::PlotDigital(
-                label_id,
-                xs.data(),
-                ys.data(),
-                xs.size(),
-                flags,
-                offset
-            );
-        },
-        "label_id"_a,
-        "xs"_a,
-        "ys"_a,
-        "flags"_a = 0,
-        "offset"_a = 0
-    );
+    initWrapperPlotting<arr<double>*>(m);
 
     m.def(
         "PlotImage",
@@ -1349,7 +814,7 @@ void init_plotting(py::module& m)
            const ImVec2& uv0,
            const ImVec2& uv1,
            const ImVec4& tint_col,
-           ImPlotImageFlags flags)
+           const ImPlotSpec& spec)
         {
             ImPlot::PlotImage(
                 label_id,
@@ -1359,7 +824,7 @@ void init_plotting(py::module& m)
                 uv0,
                 uv1,
                 tint_col,
-                flags
+                spec
             );
         },
         "label_id"_a,
@@ -1369,7 +834,7 @@ void init_plotting(py::module& m)
         py::arg_v("uv0", ImVec2(0, 0), "Vec2(0, 0)"),
         py::arg_v("uv1", ImVec2(0, 0), "Vec2(0, 0)"),
         py::arg_v("tint_col", ImVec4(1, 1, 1, 1), "Vec4(1, 1, 1, 1)"),
-        "flags"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
     m.def(
@@ -1378,8 +843,12 @@ void init_plotting(py::module& m)
         "x"_a,
         "y"_a,
         py::arg_v("pix_offset", ImVec2(0, 0), "Vec2(0, 0)"),
-        "flags"_a = 0
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
-    m.def(IMFUNC(PlotDummy), "label_id"_a, "flags"_a = 0);
+    m.def(
+        IMFUNC(PlotDummy),
+        "label_id"_a,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
 }

--- a/py-imgui-redux/src/implot/modules/implot-plotting.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-plotting.cpp
@@ -1,4 +1,5 @@
 #include <bind-imgui/implot-modules.h>
+#include <bind-imgui/implot-spec.h>
 #include <bind-imgui/texture.h>
 #include <binder/numpy.h>
 #include <binder/wraps.h>
@@ -6,6 +7,16 @@
 #include <pybind11/functional.h>
 
 using GetterCallback = std::function<ImPlotPoint(int, py::object)>;
+
+#define PLOT_FUNC_CALL(func, ...) \
+    if(py::isinstance<py::tuple>(spec)) \
+    { \
+        func(__VA_ARGS__, makeSpec(spec)); \
+    } \
+    else \
+    { \
+        func(__VA_ARGS__, spec.cast<const ImPlotSpec&>()); \
+    }
 
 struct GetterCallbackData
 {
@@ -27,15 +38,15 @@ template<typename T> void initWrapperPlotting(py::module& m)
            T values,
            double xscale,
            double xstart,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
-            ImPlot::PlotLine(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotLine,
                 label_id,
                 values->data(),
                 values->size(),
                 xscale,
-                xstart,
-                spec
+                xstart
             );
         },
         "label_id"_a,
@@ -47,13 +58,23 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotLine",
-        [](const char* label_id, T xs, T ys, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y)");
             }
-            ImPlot::PlotLine(label_id, xs->data(), ys->data(), xs->size(), spec);
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotLine,
+                label_id,
+                xs->data(),
+                ys->data(),
+                xs->size()
+            );
         },
         "label_id"_a,
         "xs"_a,
@@ -67,10 +88,17 @@ template<typename T> void initWrapperPlotting(py::module& m)
            GetterCallback getter,
            py::object data,
            int count,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             GetterCallbackData userdata{getter, data};
-            ImPlot::PlotLineG(label_id, getterCallbackFunc, &userdata, count, spec);
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotLineG,
+                label_id,
+                getterCallbackFunc,
+                &userdata,
+                count
+            );
         },
         "label_id"_a,
         "getter"_a.none(false),
@@ -85,15 +113,15 @@ template<typename T> void initWrapperPlotting(py::module& m)
            T values,
            double xscale,
            double xstart,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
-            ImPlot::PlotScatter(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotScatter,
                 label_id,
                 values->data(),
                 values->size(),
                 xscale,
-                xstart,
-                spec
+                xstart
             );
         },
         "label_id"_a,
@@ -105,13 +133,23 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotScatter",
-        [](const char* label_id, T xs, T ys, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y)");
             }
-            ImPlot::PlotScatter(label_id, xs->data(), ys->data(), xs->size(), spec);
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotScatter,
+                label_id,
+                xs->data(),
+                ys->data(),
+                xs->size()
+            )
         },
         "label_id"_a,
         "xs"_a,
@@ -125,15 +163,16 @@ template<typename T> void initWrapperPlotting(py::module& m)
            GetterCallback getter,
            py::object data,
            int count,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             GetterCallbackData userdata{getter, data};
-            ImPlot::PlotScatterG(
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotScatterG,
                 label_id,
                 getterCallbackFunc,
                 &userdata,
-                count,
-                spec
+                count
             );
         },
         "label_id"_a,
@@ -150,20 +189,21 @@ template<typename T> void initWrapperPlotting(py::module& m)
            T sizes,
            double xscale,
            double xstart,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(values->size() != sizes->size())
             {
                 throw py::value_error("len(values) != len(sizes)");
             }
-            ImPlot::PlotBubbles(
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotBubbles,
                 label_id,
                 values->data(),
                 sizes->data(),
                 values->size(),
                 xscale,
-                xstart,
-                spec
+                xstart
             );
         },
         "label_id"_a,
@@ -176,19 +216,24 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotBubbles",
-        [](const char* label_id, T xs, T ys, T sizes, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           T sizes,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y)");
             }
-            ImPlot::PlotBubbles(
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotBubbles,
                 label_id,
                 xs->data(),
                 ys->data(),
                 sizes->data(),
-                xs->size(),
-                spec
+                xs->size()
             );
         },
         "label_id"_a,
@@ -200,13 +245,23 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotPolygon",
-        [](const char* label_id, T xs, T ys, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y)");
             }
-            ImPlot::PlotPolygon(label_id, xs->data(), ys->data(), xs->size(), spec);
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotPolygon,
+                label_id,
+                xs->data(),
+                ys->data(),
+                xs->size()
+            );
         },
         "label_id"_a,
         "xs"_a,
@@ -220,15 +275,15 @@ template<typename T> void initWrapperPlotting(py::module& m)
            T values,
            double xscale,
            double xstart,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
-            ImPlot::PlotStairs(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotStairs,
                 label_id,
                 values->data(),
                 values->size(),
                 xscale,
-                xstart,
-                spec
+                xstart
             );
         },
         "label_id"_a,
@@ -240,13 +295,23 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotStairs",
-        [](const char* label_id, T xs, T ys, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y)");
             }
-            ImPlot::PlotStairs(label_id, xs->data(), ys->data(), xs->size(), spec);
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotStairs,
+                label_id,
+                xs->data(),
+                ys->data(),
+                xs->size()
+            );
         },
         "label_id"_a,
         "xs"_a,
@@ -260,15 +325,16 @@ template<typename T> void initWrapperPlotting(py::module& m)
            GetterCallback getter,
            py::object data,
            int count,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             GetterCallbackData userdata{getter, data};
-            ImPlot::PlotStairsG(
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotStairsG,
                 label_id,
                 getterCallbackFunc,
                 &userdata,
-                count,
-                spec
+                count
             );
         },
         "label_id"_a,
@@ -285,16 +351,16 @@ template<typename T> void initWrapperPlotting(py::module& m)
            double yref,
            double xscale,
            double xstart,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
-            ImPlot::PlotShaded(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotShaded,
                 label_id,
                 values->data(),
                 values->size(),
                 yref,
                 xscale,
-                xstart,
-                spec
+                xstart
             );
         },
         "label_id"_a,
@@ -307,19 +373,24 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotShaded",
-        [](const char* label_id, T xs, T ys, double yref, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           double yref,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y)");
             }
-            ImPlot::PlotShaded(
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotShaded,
                 label_id,
                 xs->data(),
                 ys->data(),
                 xs->size(),
-                yref,
-                spec
+                yref
             );
         },
         "label_id"_a,
@@ -331,19 +402,24 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotShaded",
-        [](const char* label_id, T xs, T ys1, T ys2, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys1,
+           T ys2,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys1->size() || xs->size() != ys2->size())
             {
                 throw py::value_error("len(x) != len(y1) != len(y2)");
             }
-            ImPlot::PlotShaded(
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotShaded,
                 label_id,
                 xs->data(),
                 ys1->data(),
                 ys2->data(),
-                xs->size(),
-                spec
+                xs->size()
             );
         },
         "label_id"_a,
@@ -361,18 +437,19 @@ template<typename T> void initWrapperPlotting(py::module& m)
            GetterCallback getter2,
            py::object data2,
            int count,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             GetterCallbackData cbdata1{getter1, data1};
             GetterCallbackData cbdata2{getter2, data2};
-            ImPlot::PlotShadedG(
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotShadedG,
                 label_id,
                 getterCallbackFunc,
                 &cbdata1,
                 getterCallbackFunc,
                 &cbdata2,
-                count,
-                spec
+                count
             );
         },
         "label_id"_a,
@@ -390,15 +467,15 @@ template<typename T> void initWrapperPlotting(py::module& m)
            T values,
            double bar_size,
            double shift,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
-            ImPlot::PlotBars(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotBars,
                 label_id,
                 values->data(),
                 values->size(),
                 bar_size,
-                shift,
-                spec
+                shift
             );
         },
         "label_id"_a,
@@ -410,19 +487,23 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotBars",
-        [](const char* label_id, T xs, T ys, double bar_size, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           double bar_size,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y1)");
             }
-            ImPlot::PlotBars(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotBars,
                 label_id,
                 xs->data(),
                 ys->data(),
                 xs->size(),
-                bar_size,
-                spec
+                bar_size
             );
         },
         "label_id"_a,
@@ -439,16 +520,16 @@ template<typename T> void initWrapperPlotting(py::module& m)
            py::object data,
            int count,
            double bar_size,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             GetterCallbackData userdata{getter, data};
-            ImPlot::PlotBarsG(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotBarsG,
                 label_id,
                 getterCallbackFunc,
                 &userdata,
                 count,
-                bar_size,
-                spec
+                bar_size
             );
         },
         "label_id"_a,
@@ -467,7 +548,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
            int group_count,
            double group_size,
            double shift,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(labels->size() != item_count)
             {
@@ -478,14 +559,14 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 throw py::value_error("len(values) != item_count * group_count");
             }
 
-            ImPlot::PlotBarGroups(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotBarGroups,
                 labels->data(),
                 values->data(),
                 item_count,
                 group_count,
                 group_size,
-                shift,
-                spec
+                shift
             );
         },
         "labels"_a,
@@ -499,20 +580,23 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotErrorBars",
-        [](const char* label_id, T xs, T ys, T err, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           T err,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size() || xs->size() != err->size())
             {
                 throw py::value_error("len(xs) != len(ys) != len(err)");
             }
-
-            ImPlot::PlotErrorBars(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotErrorBars,
                 label_id,
                 xs->data(),
                 ys->data(),
                 err->data(),
-                xs->size(),
-                spec
+                xs->size()
             );
         },
         "label_id"_a,
@@ -524,7 +608,12 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotErrorBars",
-        [](const char* label_id, T xs, T ys, T neg, T pos, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           T neg,
+           T pos,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size() || xs->size() != neg->size()
                || xs->size() != pos->size())
@@ -534,14 +623,14 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 );
             }
 
-            ImPlot::PlotErrorBars(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotErrorBars,
                 label_id,
                 xs->data(),
                 ys->data(),
                 neg->data(),
                 pos->data(),
-                xs->size(),
-                spec
+                xs->size()
             );
         },
         "label_id"_a,
@@ -559,16 +648,16 @@ template<typename T> void initWrapperPlotting(py::module& m)
            int ref,
            double scale,
            double start,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
-            ImPlot::PlotStems(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotStems,
                 label_id,
                 values->data(),
                 values->size(),
                 ref,
                 scale,
-                start,
-                spec
+                start
             );
         },
         "label_id"_a,
@@ -581,19 +670,23 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotStems",
-        [](const char* label_id, T xs, T ys, int ref, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           int ref,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(x) != len(y1)");
             }
-            ImPlot::PlotStems(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotStems,
                 label_id,
                 xs->data(),
                 ys->data(),
                 xs->size(),
-                ref,
-                spec
+                ref
             );
         },
         "label_id"_a,
@@ -605,9 +698,16 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotInfLines",
-        [](const char* label_id, T values, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T values,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
-            ImPlot::PlotInfLines(label_id, values->data(), values->size(), spec);
+            PLOT_FUNC_CALL(
+                ImPlot::PlotInfLines,
+                label_id,
+                values->data(),
+                values->size()
+            );
         },
         "label_id"_a,
         "values"_a,
@@ -625,13 +725,14 @@ template<typename T> void initWrapperPlotting(py::module& m)
            double radius,
            const char* label_fmt,
            double angle0,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(label_ids->size() != values->size())
             {
                 throw py::value_error("len(label_ids) != len(values)");
             }
-            ImPlot::PlotPieChart(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotPieChart,
                 label_ids->data(),
                 values->data(),
                 label_ids->size(),
@@ -639,8 +740,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 y,
                 radius,
                 label_fmt,
-                angle0,
-                spec
+                angle0
             );
         },
         "label_ids"_a,
@@ -664,14 +764,14 @@ template<typename T> void initWrapperPlotting(py::module& m)
            const char* label_fmt,
            const ImPlotPoint& bounds_min,
            const ImPlotPoint& bounds_max,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(values->size() < rows * cols)
             {
                 throw py::value_error("len(values) > rows * cols");
             }
-
-            ImPlot::PlotHeatmap(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotHeatmap,
                 label_id,
                 values->data(),
                 rows,
@@ -680,8 +780,7 @@ template<typename T> void initWrapperPlotting(py::module& m)
                 scale_max,
                 label_fmt,
                 bounds_min,
-                bounds_max,
-                spec
+                bounds_max
             );
         },
         "label_id"_a,
@@ -703,16 +802,16 @@ template<typename T> void initWrapperPlotting(py::module& m)
            int bins,
            double bar_scale,
            ImPlotRange range,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
-            ImPlot::PlotHistogram(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotHistogram,
                 label_id,
                 values->data(),
                 values->size(),
                 bins,
                 bar_scale,
-                range,
-                spec
+                range
             );
         },
         "label_id"_a,
@@ -731,21 +830,22 @@ template<typename T> void initWrapperPlotting(py::module& m)
            int x_bins,
            int y_bins,
            ImPlotRect range,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(xs) != len(ys)");
             }
-            ImPlot::PlotHistogram2D(
+
+            PLOT_FUNC_CALL(
+                ImPlot::PlotHistogram2D,
                 label_id,
                 xs->data(),
                 ys->data(),
                 xs->size(),
                 x_bins,
                 y_bins,
-                range,
-                spec
+                range
             );
         },
         "label_id"_a,
@@ -759,14 +859,22 @@ template<typename T> void initWrapperPlotting(py::module& m)
 
     m.def(
         "PlotDigital",
-        [](const char* label_id, T xs, T ys, const ImPlotSpec& spec)
+        [](const char* label_id,
+           T xs,
+           T ys,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             if(xs->size() != ys->size())
             {
                 throw py::value_error("len(xs) != len(ys)");
             }
-
-            ImPlot::PlotDigital(label_id, xs->data(), ys->data(), xs->size(), spec);
+            PLOT_FUNC_CALL(
+                ImPlot::PlotDigital,
+                label_id,
+                xs->data(),
+                ys->data(),
+                xs->size()
+            );
         },
         "label_id"_a,
         "xs"_a,
@@ -780,15 +888,15 @@ template<typename T> void initWrapperPlotting(py::module& m)
            GetterCallback getter,
            py::object data,
            int count,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
             GetterCallbackData userdata{getter, data};
-            ImPlot::PlotDigitalG(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotDigitalG,
                 label_id,
                 getterCallbackFunc,
                 &userdata,
-                count,
-                spec
+                count
             );
         },
         "label_id"_a,
@@ -814,17 +922,17 @@ void init_plotting(py::module& m)
            const ImVec2& uv0,
            const ImVec2& uv1,
            const ImVec4& tint_col,
-           const ImPlotSpec& spec)
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
         {
-            ImPlot::PlotImage(
+            PLOT_FUNC_CALL(
+                ImPlot::PlotImage,
                 label_id,
                 ImTextureRef(tex.texID),
                 bounds_min,
                 bounds_max,
                 uv0,
                 uv1,
-                tint_col,
-                spec
+                tint_col
             );
         },
         "label_id"_a,
@@ -838,7 +946,15 @@ void init_plotting(py::module& m)
     );
 
     m.def(
-        IMFUNC(PlotText),
+        "PlotText",
+        [](const char* text,
+           double x,
+           double y,
+           const ImVec2& pix_offset,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
+        {
+            PLOT_FUNC_CALL(ImPlot::PlotText, text, x, y, pix_offset);
+        },
         "text"_a,
         "x"_a,
         "y"_a,
@@ -847,7 +963,12 @@ void init_plotting(py::module& m)
     );
 
     m.def(
-        IMFUNC(PlotDummy),
+        "PlotDummy",
+        [](const char* label_id,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
+        {
+            PLOT_FUNC_CALL(ImPlot::PlotDummy, label_id);
+        },
         "label_id"_a,
         py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );

--- a/py-imgui-redux/src/implot/modules/implot-setup-funcs.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-setup-funcs.cpp
@@ -11,7 +11,18 @@ struct FormatterCallbackData
 {
     FormatterCallback callback;
     py::object userdata;
+
+    FormatterCallbackData(FormatterCallback cb, py::object ud)
+        : callback(cb)
+        , userdata(ud)
+    {
+    }
 };
+
+// Static array of axis formatters
+// These are set by SetupAxisFormat and cleared by EndPlot
+static std::vector<std::shared_ptr<FormatterCallbackData>>
+    formatterCallbacks(ImAxis_COUNT, nullptr);
 
 int plotFormatterCallback(double value, char* buff, int size, void* user_data)
 {
@@ -80,31 +91,15 @@ void init_setup_funcs(py::module& m)
         "format"_a
     );
 
-    /*
-    This is different than the imgui text callbacks, because the callback is not
-    used in this function. It is store with the user data until later.
-    Therefore, the userdata needs to exist for an indeterminate amount of time.
-
-    Presumably, the formatter is called more than once, so we can't just dealloc
-    there.
-
-    Therefore, the simplest we can do is return the user data and let python
-    take ownership and in most use cases, it won't get destructed until after
-    the plotting funcs are called.
-    */
-    py::class_<FormatterCallbackData>(m, "_FormatterCallbackData");
-
     m.def(
         "SetupAxisFormat",
         [](ImAxis axis, FormatterCallback formatter, py::object userData)
         {
-            FormatterCallbackData* data =
-                new FormatterCallbackData{formatter, userData};
-            ImPlot::SetupAxisFormat(axis, plotFormatterCallback, data);
-            return data;
+            auto data =
+                std::make_shared<FormatterCallbackData>(formatter, userData);
+            ImPlot::SetupAxisFormat(axis, plotFormatterCallback, data.get());
+            formatterCallbacks[axis] = data;
         },
-        "IMPORTANT: you must keep the return from this function around until "
-        "the next PlotXXX call",
         "axis"_a,
         "formatter"_a,
         "data"_a = py::none(),
@@ -241,8 +236,8 @@ void init_setup_funcs(py::module& m)
             ImPlot::SetNextAxisLinks(axis, a, b);
         },
         "axis"_a,
-        "link_min"_a.none(true),
-        "link_max"_a.none(true)
+        "link_min"_a,
+        "link_max"_a
     );
     m.def(IMFUNC(SetNextAxisToFit), "axis"_a);
     m.def(
@@ -254,4 +249,21 @@ void init_setup_funcs(py::module& m)
         "cond"_a = (int)ImPlotCond_Once
     );
     QUICK(SetNextAxesToFit);
+
+    m.def(
+        "EndPlot",
+        []()
+        {
+            // First end the plot
+            ImPlot::EndPlot();
+            // Then clear out the formatter callbacks
+            for(size_t i = 0; i < ImAxis_COUNT; ++i)
+            {
+                if(formatterCallbacks[i])
+                {
+                    formatterCallbacks[i].reset();
+                }
+            }
+        }
+    );
 }

--- a/py-imgui-redux/src/implot/modules/implot-setup-funcs.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-setup-funcs.cpp
@@ -38,7 +38,23 @@ struct TransformCallbackData
     TransformCallback forward;
     TransformCallback inverse;
     py::object userdata;
+
+    TransformCallbackData(
+        TransformCallback fwd,
+        TransformCallback inv,
+        py::object ud
+    )
+        : forward(fwd)
+        , inverse(inv)
+        , userdata(ud)
+    {
+    }
 };
+
+// Static array of axis transforms
+// These are set by SetupAxisScale and cleared by EndPlot
+static std::vector<std::shared_ptr<TransformCallbackData>>
+    transformCallbacks(ImAxis_COUNT, nullptr);
 
 double plotTransformCallbackForward(double value, void* user_data)
 {
@@ -171,23 +187,20 @@ void init_setup_funcs(py::module& m)
            TransformCallback inverse,
            py::object data)
         {
-            TransformCallbackData* userdata =
-                new TransformCallbackData{forward, inverse, data};
+            auto userdata =
+                std::make_shared<TransformCallbackData>(forward, inverse, data);
             ImPlot::SetupAxisScale(
                 axis,
                 plotTransformCallbackForward,
                 plotTransformCallbackInverse,
-                userdata
+                userdata.get()
             );
-            return userdata;
+            transformCallbacks[axis] = userdata;
         },
-        "IMPORTANT: you must keep the return from this function around until "
-        "the next PlotXXX call",
         "axis"_a,
         "forward"_a.none(false),
         "inverse"_a.none(false),
-        "data"_a = py::none(),
-        py::return_value_policy::take_ownership
+        "data"_a = py::none()
     );
     m.def(IMFUNC(SetupAxisLimitsConstraints), "axis"_a, "v_min"_a, "v_max"_a);
     m.def(IMFUNC(SetupAxisZoomConstraints), "axis"_a, "z_min"_a, "z_max"_a);
@@ -262,6 +275,10 @@ void init_setup_funcs(py::module& m)
                 if(formatterCallbacks[i])
                 {
                     formatterCallbacks[i].reset();
+                }
+                if(transformCallbacks[i])
+                {
+                    transformCallbacks[i].reset();
                 }
             }
         }

--- a/py-imgui-redux/src/implot/modules/implot-setup-funcs.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-setup-funcs.cpp
@@ -16,13 +16,29 @@ struct FormatterCallbackData
 int plotFormatterCallback(double value, char* buff, int size, void* user_data)
 {
     auto* data = static_cast<FormatterCallbackData*>(user_data);
-    if(data->callback)
-    {
-        EditableStrWrapper wrapper(buff, size);
-        return data->callback(value, wrapper, data->userdata);
-    }
+    EditableStrWrapper wrapper(buff, size);
+    return data->callback(value, wrapper, data->userdata);
+}
 
-    return 0;
+using TransformCallback = std::function<double(double, py::object)>;
+
+struct TransformCallbackData
+{
+    TransformCallback forward;
+    TransformCallback inverse;
+    py::object userdata;
+};
+
+double plotTransformCallbackForward(double value, void* user_data)
+{
+    auto* data = static_cast<TransformCallbackData*>(user_data);
+    return data->forward(value, data->userdata);
+}
+
+double plotTransformCallbackInverse(double value, void* user_data)
+{
+    auto* data = static_cast<TransformCallbackData*>(user_data);
+    return data->inverse(value, data->userdata);
 }
 
 void init_setup_funcs(py::module& m)
@@ -153,7 +169,31 @@ void init_setup_funcs(py::module& m)
         "axis"_a,
         "scale"_a
     );
-    // TODO setupAxisScale with callbacks
+    m.def(
+        "SetupAxisScale",
+        [](ImAxis axis,
+           TransformCallback forward,
+           TransformCallback inverse,
+           py::object data)
+        {
+            TransformCallbackData* userdata =
+                new TransformCallbackData{forward, inverse, data};
+            ImPlot::SetupAxisScale(
+                axis,
+                plotTransformCallbackForward,
+                plotTransformCallbackInverse,
+                userdata
+            );
+            return userdata;
+        },
+        "IMPORTANT: you must keep the return from this function around until "
+        "the next PlotXXX call",
+        "axis"_a,
+        "forward"_a.none(false),
+        "inverse"_a.none(false),
+        "data"_a = py::none(),
+        py::return_value_policy::take_ownership
+    );
     m.def(IMFUNC(SetupAxisLimitsConstraints), "axis"_a, "v_min"_a, "v_max"_a);
     m.def(IMFUNC(SetupAxisZoomConstraints), "axis"_a, "z_min"_a, "z_max"_a);
     m.def(
@@ -199,7 +239,10 @@ void init_setup_funcs(py::module& m)
             }
 
             ImPlot::SetNextAxisLinks(axis, a, b);
-        }
+        },
+        "axis"_a,
+        "link_min"_a.none(true),
+        "link_max"_a.none(true)
     );
     m.def(IMFUNC(SetNextAxisToFit), "axis"_a);
     m.def(

--- a/py-imgui-redux/src/implot/modules/implot-structs.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-structs.cpp
@@ -4,6 +4,27 @@
 
 void init_implot_structs(py::module& m)
 {
+    py::class_<ImPlotSpec>(m, "PlotSpec")
+        .def(py::init<>())
+        // TODO vararg constructor?
+        .RW(ImPlotSpec, LineColor)
+        .RW(ImPlotSpec, LineColors)
+        .RW(ImPlotSpec, LineWeight)
+        .RW(ImPlotSpec, FillColor)
+        .RW(ImPlotSpec, FillColors)
+        .RW(ImPlotSpec, FillAlpha)
+        .RW(ImPlotSpec, Marker)
+        .RW(ImPlotSpec, MarkerSize)
+        .RW(ImPlotSpec, MarkerSizes)
+        .RW(ImPlotSpec, MarkerLineColor)
+        .RW(ImPlotSpec, MarkerLineColors)
+        .RW(ImPlotSpec, MarkerFillColor)
+        .RW(ImPlotSpec, MarkerFillColors)
+        .RW(ImPlotSpec, Size)
+        .RW(ImPlotSpec, Offset)
+        .RW(ImPlotSpec, Stride)
+        .RW(ImPlotSpec, Flags);
+
     py::class_<ImPlotPoint>(m, "Point")
         .def(py::init<double, double>(), "x"_a = 0, "y"_a = 0)
         .RW(ImPlotPoint, x)
@@ -23,30 +44,31 @@ void init_implot_structs(py::module& m)
             "y_min"_a = 0,
             "y_max"_a = 0
         )
+        .RW(ImPlotRect, X)
+        .RW(ImPlotRect, Y)
         .def(
             "Contains",
-            static_cast<bool (ImPlotRect::*)(const ImPlotPoint&) const>(
-                &ImPlotRect::Contains
+            py::overload_cast<const ImPlotPoint&>(
+                &ImPlotRect::Contains,
+                py::const_
             ),
             "p"_a
         )
         .def(
             "Contains",
-            static_cast<bool (ImPlotRect::*)(double, double) const>(
-                &ImPlotRect::Contains
-            ),
+            py::overload_cast<double, double>(&ImPlotRect::Contains, py::const_),
             "x"_a,
             "y"_a
         )
         .def(DEF(ImPlotRect, Size))
         .def(
             "Clamp",
-            py::overload_cast<const ImPlotPoint&>(&ImPlotRect::Clamp),
+            py::overload_cast<const ImPlotPoint&>(&ImPlotRect::Clamp, py::const_),
             "p"_a
         )
         .def(
             "Clamp",
-            py::overload_cast<double, double>(&ImPlotRect::Clamp),
+            py::overload_cast<double, double>(&ImPlotRect::Clamp, py::const_),
             "x"_a,
             "y"_a
         )
@@ -54,15 +76,9 @@ void init_implot_structs(py::module& m)
         .def(DEF(ImPlotRect, Max));
 
     py::class_<ImPlotStyle>(m, "PlotStyle")
-        .RW(ImPlotStyle, LineWeight)
-        .RW(ImPlotStyle, Marker)
-        .RW(ImPlotStyle, MarkerSize)
-        .RW(ImPlotStyle, MarkerWeight)
-        .RW(ImPlotStyle, FillAlpha)
-        .RW(ImPlotStyle, ErrorBarSize)
-        .RW(ImPlotStyle, ErrorBarWeight)
-        .RW(ImPlotStyle, DigitalBitHeight)
-        .RW(ImPlotStyle, DigitalBitGap)
+        // Plot styling
+        .RW(ImPlotStyle, PlotDefaultSize)
+        .RW(ImPlotStyle, PlotMinSize)
         .RW(ImPlotStyle, PlotBorderSize)
         .RW(ImPlotStyle, MinorAlpha)
         .RW(ImPlotStyle, MajorTickLen)
@@ -71,6 +87,7 @@ void init_implot_structs(py::module& m)
         .RW(ImPlotStyle, MinorTickSize)
         .RW(ImPlotStyle, MajorGridSize)
         .RW(ImPlotStyle, MinorGridSize)
+        // Plot padding
         .RW(ImPlotStyle, PlotPadding)
         .RW(ImPlotStyle, LabelPadding)
         .RW(ImPlotStyle, LegendPadding)
@@ -79,8 +96,8 @@ void init_implot_structs(py::module& m)
         .RW(ImPlotStyle, MousePosPadding)
         .RW(ImPlotStyle, AnnotationPadding)
         .RW(ImPlotStyle, FitPadding)
-        .RW(ImPlotStyle, PlotDefaultSize)
-        .RW(ImPlotStyle, PlotMinSize)
+        .RW(ImPlotStyle, DigitalPadding)
+        .RW(ImPlotStyle, DigitalSpacing)
         .def_property_readonly(
             "Colors",
             [](ImPlotStyle* self)

--- a/py-imgui-redux/src/implot/modules/implot-structs.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-structs.cpp
@@ -2,11 +2,74 @@
 #include <binder/list-wrapper.h>
 #include <binder/struct-utility.h>
 
+#include <binder/wraps.h>
+
+#include <bind-imgui/implot-spec.h>
+
+ImPlotSpec makeSpec(py::tuple args)
+{
+    if(args.size() % 2 != 0)
+    {
+        throw py::value_error(
+            "Odd number of arguments! You must provide "
+            "(ImPlotProp, value) pairs!"
+        );
+    }
+
+    ImPlotSpec out;
+
+    for(size_t i = 0; i < args.size(); i += 2)
+    {
+        ImPlotProp prop = args[i].cast<ImPlotProp>();
+        switch(prop)
+        {
+        case ImPlotProp_LineColor:
+        case ImPlotProp_FillColor:
+        case ImPlotProp_MarkerLineColor:
+        case ImPlotProp_MarkerFillColor:
+            out.SetProp(prop, args[i + 1].cast<ImVec4>());
+            break;
+
+        case ImPlotProp_LineColors:
+        case ImPlotProp_FillColors:
+        case ImPlotProp_MarkerLineColors:
+        case ImPlotProp_MarkerFillColors:
+            out.SetProp(prop, args[i + 1].cast<ImU32ListPtr>()->data());
+            break;
+
+        case ImPlotProp_LineWeight:
+        case ImPlotProp_FillAlpha:
+        case ImPlotProp_MarkerSize:
+        case ImPlotProp_Size:
+            out.SetProp(prop, args[i + 1].cast<float>());
+            break;
+
+        case ImPlotProp_Offset:
+        case ImPlotProp_Stride:
+        case ImPlotProp_Marker:
+        case ImPlotProp_Flags:
+            out.SetProp(prop, args[i + 1].cast<int>());
+            break;
+
+        case ImPlotProp_MarkerSizes:
+            out.SetProp(prop, args[i + 1].cast<FloatListPtr>()->data());
+            break;
+
+        default:
+            std::stringstream ss;
+            ss << "Invalid implot.PlotProp value '" << prop << "'";
+            throw py::value_error(ss.str());
+        }
+    }
+
+    return out;
+}
+
 void init_implot_structs(py::module& m)
 {
     py::class_<ImPlotSpec>(m, "PlotSpec")
         .def(py::init<>())
-        // TODO vararg constructor?
+        .def(py::init(py::overload_cast<py::tuple>(&makeSpec)))
         .RW(ImPlotSpec, LineColor)
         .RW(ImPlotSpec, LineColors)
         .RW(ImPlotSpec, LineWeight)

--- a/py-imgui-redux/src/implot/modules/implot-structs.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-structs.cpp
@@ -20,44 +20,121 @@ ImPlotSpec makeSpec(py::tuple args)
 
     for(size_t i = 0; i < args.size(); i += 2)
     {
-        ImPlotProp prop = args[i].cast<ImPlotProp>();
-        switch(prop)
+        ImPlotProp prop;
+        try
         {
-        case ImPlotProp_LineColor:
-        case ImPlotProp_FillColor:
-        case ImPlotProp_MarkerLineColor:
-        case ImPlotProp_MarkerFillColor:
-            out.SetProp(prop, args[i + 1].cast<ImVec4>());
-            break;
-
-        case ImPlotProp_LineColors:
-        case ImPlotProp_FillColors:
-        case ImPlotProp_MarkerLineColors:
-        case ImPlotProp_MarkerFillColors:
-            out.SetProp(prop, args[i + 1].cast<ImU32ListPtr>()->data());
-            break;
-
-        case ImPlotProp_LineWeight:
-        case ImPlotProp_FillAlpha:
-        case ImPlotProp_MarkerSize:
-        case ImPlotProp_Size:
-            out.SetProp(prop, args[i + 1].cast<float>());
-            break;
-
-        case ImPlotProp_Offset:
-        case ImPlotProp_Stride:
-        case ImPlotProp_Marker:
-        case ImPlotProp_Flags:
-            out.SetProp(prop, args[i + 1].cast<int>());
-            break;
-
-        case ImPlotProp_MarkerSizes:
-            out.SetProp(prop, args[i + 1].cast<FloatListPtr>()->data());
-            break;
-
-        default:
+            prop = args[i].cast<ImPlotProp>();
+        }
+        catch(py::cast_error& err)
+        {
             std::stringstream ss;
-            ss << "Invalid implot.PlotProp value '" << prop << "'";
+            ss << "Invalid PlotProp at index " << i << ": " << err.what();
+            throw py::value_error(ss.str());
+        }
+
+        try
+        {
+            switch(prop)
+            {
+            case ImPlotProp_LineColor:
+            case ImPlotProp_FillColor:
+            case ImPlotProp_MarkerLineColor:
+            case ImPlotProp_MarkerFillColor:
+                out.SetProp(prop, args[i + 1].cast<ImVec4>());
+                break;
+
+            case ImPlotProp_LineColors:
+            case ImPlotProp_FillColors:
+            case ImPlotProp_MarkerLineColors:
+            case ImPlotProp_MarkerFillColors:
+                out.SetProp(prop, args[i + 1].cast<ImU32ListPtr>()->data());
+                break;
+
+            case ImPlotProp_LineWeight:
+            case ImPlotProp_FillAlpha:
+            case ImPlotProp_MarkerSize:
+            case ImPlotProp_Size:
+                out.SetProp(prop, args[i + 1].cast<float>());
+                break;
+
+            case ImPlotProp_Offset:
+            case ImPlotProp_Stride:
+            case ImPlotProp_Marker:
+            case ImPlotProp_Flags:
+                out.SetProp(prop, args[i + 1].cast<int>());
+                break;
+
+            case ImPlotProp_MarkerSizes:
+                out.SetProp(prop, args[i + 1].cast<FloatListPtr>()->data());
+                break;
+
+            default:
+                std::stringstream ss;
+                ss << "Invalid PlotProp enumeration (" << prop << ")";
+                throw py::value_error(ss.str());
+            }
+        }
+        catch(py::cast_error& err)
+        {
+            std::stringstream ss;
+            ss << "Invalid type for property ";
+            switch(prop)
+            {
+            case ImPlotProp_LineColor:
+                ss << "PlotProp.LineColor";
+                break;
+            case ImPlotProp_FillColor:
+                ss << "PlotProp.FillColor";
+                break;
+            case ImPlotProp_MarkerLineColor:
+                ss << "PlotProp.MarkerLineColor";
+                break;
+            case ImPlotProp_MarkerFillColor:
+                ss << "PlotProp.MarkerFillColor";
+                break;
+            case ImPlotProp_LineColors:
+                ss << "PlotProp.LineColors";
+                break;
+            case ImPlotProp_FillColors:
+                ss << "PlotProp.FillColors";
+                break;
+            case ImPlotProp_MarkerLineColors:
+                ss << "PlotProp.MarkerLineColors";
+                break;
+            case ImPlotProp_MarkerFillColors:
+                ss << "PlotProp.MarkerFillColors";
+                break;
+            case ImPlotProp_LineWeight:
+                ss << "PlotProp.LineWeight";
+                break;
+            case ImPlotProp_FillAlpha:
+                ss << "PlotProp.FillAlpha";
+                break;
+            case ImPlotProp_MarkerSize:
+                ss << "PlotProp.MarkerSize";
+                break;
+            case ImPlotProp_Size:
+                ss << "PlotProp.Size";
+                break;
+            case ImPlotProp_Offset:
+                ss << "PlotProp.Offset";
+                break;
+            case ImPlotProp_Stride:
+                ss << "PlotProp.Stride";
+                break;
+            case ImPlotProp_Marker:
+                ss << "PlotProp.Marker";
+                break;
+            case ImPlotProp_Flags:
+                ss << "PlotProp.Flags";
+                break;
+            case ImPlotProp_MarkerSizes:
+                ss << "PlotProp.MarkerSizes";
+                break;
+            }
+
+            ss << " at index " << i << ": " << err.what();
+
             throw py::value_error(ss.str());
         }
     }

--- a/py-imgui-redux/src/implot/modules/implot-tools.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-tools.cpp
@@ -1,81 +1,208 @@
 #include <bind-imgui/implot-modules.h>
 
+#include <binder/wraps.h>
+
 void init_tools(py::module& m)
 {
     m.def(
         "DragPoint",
         [](int id,
-           double x,
-           double y,
+           DoubleRef xRef,
+           DoubleRef yRef,
            const ImVec4& col,
            float size,
-           ImPlotDragToolFlags flags)
+           ImPlotDragToolFlags flags,
+           BoolRef outClickedRef,
+           BoolRef outHoveredRef,
+           BoolRef outHeldRef)
         {
-            bool out = ImPlot::DragPoint(id, &x, &y, col, size, flags);
-            return py::make_tuple(out, x, y);
+            double* x = nullptr;
+            double* y = nullptr;
+            bool* outClicked = nullptr;
+            bool* outHovered = nullptr;
+            bool* outHeld = nullptr;
+
+            if(outClickedRef)
+            {
+                outClicked = &outClickedRef->val;
+            }
+            if(outHoveredRef)
+            {
+                outHovered = &outHoveredRef->val;
+            }
+            if(outHeldRef)
+            {
+                outHeld = &outHeldRef->val;
+            }
+
+            return ImPlot::DragPoint(
+                id,
+                &xRef->val,
+                &yRef->val,
+                col,
+                size,
+                flags,
+                outClicked,
+                outHovered,
+                outHeld
+            );
         },
         "id"_a,
-        "x"_a,
-        "y"_a,
+        "x"_a.none(false),
+        "y"_a.none(false),
         "col"_a,
         "size"_a = 4,
-        "flags"_a = 0
+        "flags"_a = 0,
+        "out_clicked"_a = nullptr,
+        "out_hovered"_a = nullptr,
+        "out_held"_a = nullptr
     );
 
     m.def(
         "DragLineX",
         [](int id,
-           double x,
+           DoubleRef xRef,
            const ImVec4& col,
            float thickness,
-           ImPlotDragToolFlags flags)
+           ImPlotDragToolFlags flags,
+           BoolRef outClickedRef,
+           BoolRef outHoveredRef,
+           BoolRef outHeldRef)
         {
-            bool out = ImPlot::DragLineX(id, &x, col, thickness, flags);
-            return py::make_tuple(out, x);
+            bool* outClicked = nullptr;
+            bool* outHovered = nullptr;
+            bool* outHeld = nullptr;
+            if(outClickedRef)
+            {
+                outClicked = &outClickedRef->val;
+            }
+            if(outHoveredRef)
+            {
+                outHovered = &outHoveredRef->val;
+            }
+            if(outHeldRef)
+            {
+                outHeld = &outHeldRef->val;
+            }
+            return ImPlot::DragLineX(
+                id,
+                &xRef->val,
+                col,
+                thickness,
+                flags,
+                outClicked,
+                outHovered,
+                outHeld
+            );
         },
         "id"_a,
-        "x"_a,
+        "x"_a.none(false),
         "col"_a,
         "thickness"_a = 1,
-        "flags"_a = 0
+        "flags"_a = 0,
+        "out_clicked"_a = nullptr,
+        "out_hovered"_a = nullptr,
+        "out_held"_a = nullptr
     );
     m.def(
         "DragLineY",
         [](int id,
-           double y,
+           DoubleRef yRef,
            const ImVec4& col,
            float thickness,
-           ImPlotDragToolFlags flags)
+           ImPlotDragToolFlags flags,
+           BoolRef outClickedRef,
+           BoolRef outHoveredRef,
+           BoolRef outHeldRef)
         {
-            bool out = ImPlot::DragLineY(id, &y, col, thickness, flags);
-            return py::make_tuple(out, y);
+            bool* outClicked = nullptr;
+            bool* outHovered = nullptr;
+            bool* outHeld = nullptr;
+            if(outClickedRef)
+            {
+                outClicked = &outClickedRef->val;
+            }
+            if(outHoveredRef)
+            {
+                outHovered = &outHoveredRef->val;
+            }
+            if(outHeldRef)
+            {
+                outHeld = &outHeldRef->val;
+            }
+            return ImPlot::DragLineY(
+                id,
+                &yRef->val,
+                col,
+                thickness,
+                flags,
+                outClicked,
+                outHovered,
+                outHeld
+            );
         },
         "id"_a,
-        "y"_a,
+        "y"_a.none(false),
         "col"_a,
         "thickness"_a = 1,
-        "flags"_a = 0
+        "flags"_a = 0,
+        "out_clicked"_a = nullptr,
+        "out_hovered"_a = nullptr,
+        "out_held"_a = nullptr
     );
+
     m.def(
         "DragRect",
         [](int id,
-           double x1,
-           double y1,
-           double x2,
-           double y2,
+           DoubleRef x1,
+           DoubleRef y1,
+           DoubleRef x2,
+           DoubleRef y2,
            const ImVec4& col,
-           ImPlotDragToolFlags flags)
+           ImPlotDragToolFlags flags,
+           BoolRef outClickedRef,
+           BoolRef outHoveredRef,
+           BoolRef outHeldRef)
         {
-            bool out = ImPlot::DragRect(id, &x1, &y1, &x2, &y2, col, flags);
-            return py::make_tuple(out, x1, y1, x2, y2);
+            bool* outClicked = nullptr;
+            bool* outHovered = nullptr;
+            bool* outHeld = nullptr;
+            if(outClickedRef)
+            {
+                outClicked = &outClickedRef->val;
+            }
+            if(outHoveredRef)
+            {
+                outHovered = &outHoveredRef->val;
+            }
+            if(outHeldRef)
+            {
+                outHeld = &outHeldRef->val;
+            }
+
+            return ImPlot::DragRect(
+                id,
+                &x1->val,
+                &y1->val,
+                &x2->val,
+                &y2->val,
+                col,
+                flags,
+                outClicked,
+                outHovered,
+                outHeld
+            );
         },
         "id"_a,
-        "x1"_a,
-        "y1"_a,
-        "x2"_a,
-        "y2"_a,
+        "x1"_a.none(false),
+        "y1"_a.none(false),
+        "x2"_a.none(false),
+        "y2"_a.none(false),
         "col"_a,
-        "flags"_a = 0
+        "flags"_a = 0,
+        "out_clicked"_a = nullptr,
+        "out_hovered"_a = nullptr,
+        "out_held"_a = nullptr
     );
 
     m.def(
@@ -90,6 +217,7 @@ void init_tools(py::module& m)
         "clamp"_a,
         "round"_a = false
     );
+
     m.def(
         "Annotation",
         [](double x,

--- a/py-imgui-redux/src/implot/modules/implot-utils.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-utils.cpp
@@ -26,7 +26,8 @@ void init_utils(py::module& m)
 
     m.def(
         "PlotToPixels",
-        py::overload_cast<const ImPlotPoint&, ImAxis, ImAxis>(ImPlot::PlotToPixels
+        py::overload_cast<const ImPlotPoint&, ImAxis, ImAxis>(
+            ImPlot::PlotToPixels
         ),
         "plt"_a,
         "x_axis"_a = IMPLOT_AUTO,
@@ -137,35 +138,9 @@ void init_utils(py::module& m)
     );
     m.def(IMFUNC(PopStyleVar), "count"_a = 1);
 
-    m.def(
-        IMFUNC(SetNextLineStyle),
-        py::arg_v("col", IMPLOT_AUTO_COL, AUTO_COL_STR),
-        "weight"_a = IMPLOT_AUTO
-    );
-
-    m.def(
-        IMFUNC(SetNextFillStyle),
-        py::arg_v("col", IMPLOT_AUTO_COL, AUTO_COL_STR),
-        "alpha_mod"_a = IMPLOT_AUTO
-    );
-
-    m.def(
-        IMFUNC(SetNextMarkerStyle),
-        "marker"_a = IMPLOT_AUTO,
-        "size"_a = IMPLOT_AUTO,
-        py::arg_v("fill", IMPLOT_AUTO_COL, AUTO_COL_STR),
-        "weight"_a = IMPLOT_AUTO,
-        py::arg_v("outline", IMPLOT_AUTO_COL, AUTO_COL_STR)
-    );
-
-    m.def(
-        IMFUNC(SetNextErrorBarStyle),
-        py::arg_v("col", IMPLOT_AUTO_COL, AUTO_COL_STR),
-        "size"_a = IMPLOT_AUTO,
-        "weight"_a = IMPLOT_AUTO
-    );
-
     QUICK(GetLastItemColor);
     m.def(IMFUNC(GetStyleColorName), "idx"_a);
     m.def(IMFUNC(GetMarkerName), "idx"_a);
+
+    QUICK(NextMarker);
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ egg_base = "build"
 
 [project]
 name = "py-imgui-redux"
-version = "6.2.0"
+version = "7.0.0"
 authors = [{ name = "Alagyn" }]
 description = "A python wrapper for DearImGUI and popular extensions"
 readme = "README.md"


### PR DESCRIPTION
Bumped the package version to v7.0.0 to reflect breaking changes.

Uneventfully updated pybind11 to v3.0.4.
Updated ImPlot to the official v1.0 version.
This includes breaking changes to the `PlotXXX` functions to accommodate new `PlotSpec` structs used to configure the plotting, replacing the now removed `SetNextXXX` functions.

Additional Changes:
- Improved `implot.SetupAxisFormat` using a callback, so that you are not required to hold onto the return value anymore
- Implemented the `PlotXXXG` functions that take a callback function to produce the data
- Renamed `ImWCharList` -> `ImU32List`
- Fixed typing on the list functions
