### PR TITLE
Refactor StrList. Add PlotPieChart overload. Optimize ImPlotSpec factory

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "run-example",
             "type": "debugpy",
             "request": "launch",
-            "program": "${workspaceFolder}/examples/stock_widgets.py",
+            "program": "${workspaceFolder}/examples/implot_example.py",
             "cwd": "${workspaceFolder}/examples",
             "console": "integratedTerminal",
             "justMyCode": true,

--- a/examples/implot_example.py
+++ b/examples/implot_example.py
@@ -40,6 +40,16 @@ def customScaleInverse(value: float, data) -> float:
     return math.pow(data, value)
 
 
+def pieChartFormatter(val: float, buf: imgui.EditableStrWrapper, userData):
+    if val > 0.3:
+        label = f'wow {val}, {userData}'
+    else:
+        label = f'{val}'
+
+    buf.set(label)
+    return 0
+
+
 class State:
 
     def __init__(self) -> None:
@@ -61,6 +71,9 @@ class State:
             )
         self.plotIdx = 0
 
+        self.pieLabels = imgui.StrList(("One", "Two", "Three"))
+        self.pieValues = imgui.DoubleList((0.2, 0.1, 0.7))
+
         self.lastUpate = 0
         self.updatePeriod = 0.5
         self.t = 0
@@ -79,6 +92,9 @@ class State:
                 implot.SetNextAxesLimits(
                     -0.1, 7, -1.3, 1.3, cond=implot.Cond.Always
                 )
+            if imgui.RadioButton("Pie Chart", self.plotMode == 3):
+                self.plotMode = 3
+                implot.SetNextAxesToFit()
 
             if implot.BeginPlot("data", imgui.Vec2(500, 500)):
                 if self.plotMode == 0:
@@ -132,6 +148,16 @@ class State:
                     size = 200
                     self.t += dt * 0.5
                     implot.PlotLineG("Custom", dataGetter, self.t, size)
+                elif self.plotMode == 3:
+                    implot.PlotPieChart(
+                        self.pieLabels,
+                        self.pieValues,
+                        1.0,
+                        1.0,
+                        5.0,
+                        pieChartFormatter,
+                        "myData"
+                    )
                 implot.EndPlot()
         imgui.End()
 

--- a/py-imgui-redux/inc/bind-imgui/implot-formatter-callback.h
+++ b/py-imgui-redux/inc/bind-imgui/implot-formatter-callback.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <pybind11/functional.h>
+
+#include <binder/wraps.h>
+
+using FormatterCallback =
+    std::function<int(double, EditableStrWrapper, py::object)>;
+
+struct FormatterCallbackData
+{
+    FormatterCallback callback;
+    py::object userdata;
+
+    FormatterCallbackData(FormatterCallback cb, py::object ud)
+        : callback(cb)
+        , userdata(ud)
+    {
+    }
+};
+
+int plotFormatterCallback(double value, char* buff, int size, void* user_data);

--- a/py-imgui-redux/inc/binder/wraps.h
+++ b/py-imgui-redux/inc/binder/wraps.h
@@ -312,6 +312,16 @@ public:
     {
     }
 
+    ImList(pybind11::typing::Iterable<T> pvals)
+    {
+        vals.reserve(pybind11::len(pvals));
+        pybind11::iterator iter = pvals.begin();
+        for(pybind11::iterator end = pvals.end(); iter != end; ++iter)
+        {
+            vals.push_back(iter->cast<T>());
+        }
+    }
+
     ImList()
         : vals()
     {
@@ -377,9 +387,6 @@ using FloatListPtr = FloatList*;
 using DoubleList = ImList<double>;
 using DoubleListPtr = DoubleList*;
 
-using StrList = ImList<const char*>;
-using StrListPtr = StrList*;
-
 using Vec2List = ImList<ImVec2>;
 using Vec2ListPtr = Vec2List*;
 
@@ -412,3 +419,34 @@ public:
     char* buff;
     size_t maxSize;
 };
+
+// Separate wrapper so we can maintain a list
+// of std::string to handle the memory management,
+// and also a vector of ptrs to the start of each string
+class StrList
+{
+public:
+    StrList()
+    {
+    }
+
+    size_t size();
+    const char** data();
+
+    void append(const std::string& val);
+    void pop();
+    std::string getItem(size_t idx);
+    void setItem(size_t idx, const std::string& val);
+    void clear();
+
+    pybind11::iterator makeIter();
+
+    void reserve(size_t size);
+
+private:
+    std::vector<std::string> strs;
+    // Pointers to the beginning of each string
+    std::vector<const char*> str_ptrs;
+};
+
+using StrListPtr = StrList*;

--- a/py-imgui-redux/src/binder/wraps.cpp
+++ b/py-imgui-redux/src/binder/wraps.cpp
@@ -61,6 +61,56 @@ void StrRef::calcLen()
     this->strLen = strnlen(vals.data(), vals.size());
 }
 
+size_t StrList::size()
+{
+    return strs.size();
+}
+
+const char** StrList::data()
+{
+    return str_ptrs.data();
+}
+
+void StrList::append(const std::string& val)
+{
+    strs.push_back(val);
+    str_ptrs.push_back(strs.back().data());
+}
+
+void StrList::pop()
+{
+    strs.pop_back();
+    str_ptrs.pop_back();
+}
+
+std::string StrList::getItem(size_t idx)
+{
+    return strs[idx];
+}
+
+void StrList::setItem(size_t idx, const std::string& val)
+{
+    strs[idx] = val;
+    str_ptrs[idx] = strs[idx].data();
+}
+
+void StrList::clear()
+{
+    strs.clear();
+    str_ptrs.clear();
+}
+
+void StrList::reserve(size_t size)
+{
+    strs.reserve(size);
+    str_ptrs.reserve(size);
+}
+
+pybind11::iterator StrList::makeIter()
+{
+    return pybind11::make_iterator(str_ptrs.begin(), str_ptrs.end());
+}
+
 template<class T, class U>
 void initRef(py::module& m, const char* name, const char* desc, U defaultVal)
 {
@@ -135,8 +185,8 @@ template<class T, class U>
 py::class_<T> initList(py::module& m, const char* name, const char* desc)
 {
     return py::class_<T>(m, name, desc)
-        .def(py::init<std::vector<U>>(), "vals"_a = std::vector<U>())
         .def(py::init<>())
+        .def(py::init<py::typing::Iterable<U>>(), "vals"_a)
         .def("append", &T::append, "val"_a, "Append a value to the end")
         .def("pop", &T::pop, "Pop a value from the end")
         .def(
@@ -208,11 +258,6 @@ void init_wraps(py::module& m)
         "DoubleList",
         "Thin wrapper over a std::vector<double>"
     );
-    initList<StrList, const char*>(
-        m,
-        "StrList",
-        "Thin wrapper over a std::vector<const char*>"
-    );
     initList<Vec2List, ImVec2>(
         m,
         "Vec2List",
@@ -262,6 +307,35 @@ void init_wraps(py::module& m)
             "the maxSize will remain unchanged and extra chars will be "
             "dropped"
         );
+
+    py::class_<StrList>(
+        m,
+        "StrList",
+        "A thin wrapper around std::vector<const char*>"
+    )
+        .def(py::init<>())
+        .def(
+            py::init(
+                [](py::typing::Iterable<std::string> vals)
+                {
+                    StrList out;
+                    out.reserve(py::len(vals));
+                    for(auto val : vals)
+                    {
+                        out.append(val.cast<std::string>());
+                    }
+                    return out;
+                }
+            ),
+            "vals"_a
+        )
+        .def("append", &StrList::append, "val"_a, "Append a value to the end")
+        .def("pop", &StrList::pop, "Pop a value from the end")
+        .def("clear", &StrList::clear)
+        .def("__len__", &StrList::size)
+        .def("__iter__", &StrList::makeIter)
+        .def("__getitem__", &StrList::getItem, "index"_a)
+        .def("__setitem__", &StrList::setItem, "index"_a, "val"_a);
 
     initListWrapper<unsigned char>(m, "ListWrapperUC");
     initListWrapper<unsigned short>(m, "ListWrapperUS");

--- a/py-imgui-redux/src/implot/modules/implot-plotting.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-plotting.cpp
@@ -1,4 +1,6 @@
 #include <bind-imgui/implot-modules.h>
+
+#include <bind-imgui/implot-formatter-callback.h>
 #include <bind-imgui/implot-spec.h>
 #include <bind-imgui/texture.h>
 #include <binder/numpy.h>
@@ -714,7 +716,46 @@ template<typename T> void initWrapperPlotting(py::module& m)
         py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
     );
 
-    // TODO PlotPieChart with formatter?
+    m.def(
+        "PlotPieChart",
+        [](StrListPtr label_ids,
+           T values,
+           double x,
+           double y,
+           double radius,
+           FormatterCallback fmt,
+           py::object fmt_data,
+           double angle0,
+           py::typing::Union<const ImPlotSpec&, py::tuple> spec)
+        {
+            if(label_ids->size() != values->size())
+            {
+                throw py::value_error("len(label_ids) != len(values)");
+            }
+            FormatterCallbackData data(fmt, fmt_data);
+            PLOT_FUNC_CALL(
+                ImPlot::PlotPieChart,
+                label_ids->data(),
+                values->data(),
+                label_ids->size(),
+                x,
+                y,
+                radius,
+                plotFormatterCallback,
+                &data,
+                angle0
+            );
+        },
+        "label_ids"_a,
+        "values"_a,
+        "x"_a,
+        "y"_a,
+        "radius"_a,
+        "fmt"_a.none(false),
+        "fmt_data"_a = py::none(),
+        "angle0"_a = 90,
+        py::arg_v("spec", ImPlotSpec(), "PlotSpec()")
+    );
 
     m.def(
         "PlotPieChart",

--- a/py-imgui-redux/src/implot/modules/implot-setup-funcs.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-setup-funcs.cpp
@@ -1,23 +1,10 @@
 #include <bind-imgui/implot-modules.h>
+
+#include <bind-imgui/implot-formatter-callback.h>
 #include <binder/list-wrapper.h>
 #include <binder/wraps.h>
 
 #include <pybind11/functional.h>
-
-using FormatterCallback =
-    std::function<int(double, EditableStrWrapper, py::object)>;
-
-struct FormatterCallbackData
-{
-    FormatterCallback callback;
-    py::object userdata;
-
-    FormatterCallbackData(FormatterCallback cb, py::object ud)
-        : callback(cb)
-        , userdata(ud)
-    {
-    }
-};
 
 // Static array of axis formatters
 // These are set by SetupAxisFormat and cleared by EndPlot

--- a/py-imgui-redux/src/implot/modules/implot-structs.cpp
+++ b/py-imgui-redux/src/implot/modules/implot-structs.cpp
@@ -34,40 +34,61 @@ ImPlotSpec makeSpec(py::tuple args)
 
         try
         {
+            // Could simplify this and use spec.SetProp(), but that adds another
+            // switch and extra branching
             switch(prop)
             {
             case ImPlotProp_LineColor:
-            case ImPlotProp_FillColor:
-            case ImPlotProp_MarkerLineColor:
-            case ImPlotProp_MarkerFillColor:
-                out.SetProp(prop, args[i + 1].cast<ImVec4>());
+                out.LineColor = args[i + 1].cast<ImVec4>();
                 break;
-
             case ImPlotProp_LineColors:
-            case ImPlotProp_FillColors:
-            case ImPlotProp_MarkerLineColors:
-            case ImPlotProp_MarkerFillColors:
-                out.SetProp(prop, args[i + 1].cast<ImU32ListPtr>()->data());
+                out.LineColors = args[i + 1].cast<ImU32ListPtr>()->data();
                 break;
-
             case ImPlotProp_LineWeight:
+                out.LineWeight = args[i + 1].cast<float>();
+                break;
+            case ImPlotProp_FillColor:
+                out.FillColor = args[i + 1].cast<ImVec4>();
+                break;
+            case ImPlotProp_FillColors:
+                out.FillColors = args[i + 1].cast<ImU32ListPtr>()->data();
+                break;
             case ImPlotProp_FillAlpha:
-            case ImPlotProp_MarkerSize:
-            case ImPlotProp_Size:
-                out.SetProp(prop, args[i + 1].cast<float>());
+                out.FillAlpha = args[i + 1].cast<float>();
                 break;
-
-            case ImPlotProp_Offset:
-            case ImPlotProp_Stride:
             case ImPlotProp_Marker:
-            case ImPlotProp_Flags:
-                out.SetProp(prop, args[i + 1].cast<int>());
+                out.Marker = args[i + 1].cast<int>();
                 break;
-
+            case ImPlotProp_MarkerSize:
+                out.MarkerSize = args[i + 1].cast<float>();
+                break;
             case ImPlotProp_MarkerSizes:
-                out.SetProp(prop, args[i + 1].cast<FloatListPtr>()->data());
+                out.MarkerSizes = args[i + 1].cast<FloatListPtr>()->data();
                 break;
-
+            case ImPlotProp_MarkerLineColor:
+                out.MarkerLineColor = args[i + 1].cast<ImVec4>();
+                break;
+            case ImPlotProp_MarkerLineColors:
+                out.MarkerLineColors = args[i + 1].cast<ImU32ListPtr>()->data();
+                break;
+            case ImPlotProp_MarkerFillColor:
+                out.MarkerFillColor = args[i + 1].cast<ImVec4>();
+                break;
+            case ImPlotProp_MarkerFillColors:
+                out.MarkerFillColors = args[i + 1].cast<ImU32ListPtr>()->data();
+                break;
+            case ImPlotProp_Size:
+                out.Size = args[i + 1].cast<float>();
+                break;
+            case ImPlotProp_Offset:
+                out.Offset = args[i + 1].cast<int>();
+                break;
+            case ImPlotProp_Stride:
+                out.Stride = args[i + 1].cast<int>();
+                break;
+            case ImPlotProp_Flags:
+                out.Flags = args[i + 1].cast<int>();
+                break;
             default:
                 std::stringstream ss;
                 ss << "Invalid PlotProp enumeration (" << prop << ")";


### PR DESCRIPTION
- Fixed a memory leak with `StrList`. Now holds onto both a vector of `std::string` and a vector of pointers to the start of each string. 
- Improved `XXXList` iterable constructor.
- Added PlotPieChart overload with formatter callback.
- Optimize `makeSpec` by manually setting values instead of using `SetProp` (thus avoiding a second switch branch)
